### PR TITLE
dialog: add scroll ability when scrolling with wheel

### DIFF
--- a/src/Dialog.jsx
+++ b/src/Dialog.jsx
@@ -82,7 +82,7 @@ const Dialog = React.createClass({
 
   componentWillUnmount() {
     window.onmousewheel = null;
-  }
+  },
 
   componentDidUpdate(prevProps) {
     const props = this.props;

--- a/src/Dialog.jsx
+++ b/src/Dialog.jsx
@@ -51,6 +51,7 @@ const Dialog = React.createClass({
     maskClosable: PropTypes.bool,
     visible: PropTypes.bool,
     mousePosition: PropTypes.object,
+    scrollable: PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -60,13 +61,28 @@ const Dialog = React.createClass({
     };
   },
 
+  getInitialState() {
+    return {
+      top: 0,
+    };
+  }
+
   componentWillMount() {
     this.titleId = `rcDialogTitle${uuid++}`;
   },
 
   componentDidMount() {
     this.componentDidUpdate({});
+    if (this.props.scrollable) {
+      window.onmousewheel = (evt) => {
+        this.setState({top: this.state.top + evt.wheelDeltaY});
+      };
+    }
   },
+
+  componentWillUnmount() {
+    window.onmousewheel = null;
+  }
 
   componentDidUpdate(prevProps) {
     const props = this.props;
@@ -177,6 +193,9 @@ const Dialog = React.createClass({
     const style = {
       ...props.style,
       ...dest,
+      {
+        marginTop: this.state.top
+      }
     };
     const transitionName = this.getTransitionName();
     const dialogElement = (


### PR DESCRIPTION
Add the ability to scroll the modal when user don't want the container view 
doesn't have scroll bar.

Added the new property `scrollable` to enable this feature.