### PR TITLE
fix: resolve removeScrollingEffect not execution when this.refs.wrap …

### DIFF
--- a/src/Dialog.jsx
+++ b/src/Dialog.jsx
@@ -118,8 +118,8 @@ const Dialog = React.createClass({
     // https://github.com/react-component/dialog/pull/28
     if (this.refs.wrap) {
       this.refs.wrap.style.display = 'none';
-      this.removeScrollingEffect();
     }
+    this.removeScrollingEffect();
     this.props.onAfterClose();
   },
 


### PR DESCRIPTION
当this.refs.wrap 为 undefined时，romveScrollingEffect没有被执行，body标签的antd-modal-open没有被移除，导致屏幕不能滚动。