### PR TITLE
add ios orientations support

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -213,6 +213,7 @@ export default class RCModal extends React.Component<IModalPropTypes, any> {
         visible
         transparent
         onRequestClose={this.props.onClose}
+        supportedOrientations={['portrait', 'landscape']}
       >
         <View style={[styles.wrap, props.wrapStyle]}>
           <TouchableWithoutFeedback


### PR DESCRIPTION
On iOS, the modal is still restricted by what's specified in your app's Info.plist's UISupportedInterfaceOrientations field. [react native doc modal](http://facebook.github.io/react-native/releases/0.44/docs/modal.html), so need add flowing code to support supportedOrientations,

```jsx
<Modal
        visible={true}
        supportedOrientations={['portrait', 'landscape']}  // 使ios上支持横屏显示
>
</Modal>
```
![image](https://user-images.githubusercontent.com/14126445/29450392-1d06f2be-8431-11e7-9e85-8d16218e0c64.png)

see [issue](https://github.com/facebook/react-native/issues/11036)