### PR TITLE
react native 弹窗输入框 键盘遮挡问题

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -3,7 +3,7 @@ import {
   View, Modal, Animated,
   TouchableWithoutFeedback,
   StyleSheet, Dimensions,
-  Easing,
+  Easing, KeyboardAvoidingView
 } from 'react-native';
 
 const styles = StyleSheet.create({
@@ -215,7 +215,7 @@ export default class RCModal extends React.Component<IModalPropTypes, any> {
         onRequestClose={this.props.onClose}
         supportedOrientations={['portrait', 'landscape']}
       >
-        <View style={[styles.wrap, props.wrapStyle]}>
+        <KeyboardAvoidingView style={[styles.wrap, props.wrapStyle]} behavior={'padding'}>
           <TouchableWithoutFeedback
             onPress={ this.onMaskClose }
           >
@@ -230,7 +230,7 @@ export default class RCModal extends React.Component<IModalPropTypes, any> {
           >
             {this.props.children}
           </Animated.View>
-        </View>
+        </KeyboardAvoidingView>
       </Modal>
     );
   }


### PR DESCRIPTION
相关问题 https://github.com/ant-design/ant-design-mobile/issues/1489
在 antd-mobile 的 KeyboardAvoidingView 闭没有解决键盘问题，应该把KeyboardAvoidingView放在modal下处理

![image](https://user-images.githubusercontent.com/14126445/30007834-2171925c-914a-11e7-886a-c010e6d0fe51.png)
