### PR TITLE
fix footer padding style

### DIFF
--- a/assets/index/Dialog.less
+++ b/assets/index/Dialog.less
@@ -71,7 +71,7 @@
 
   &-footer {
     border-top: 1px solid #e9e9e9;
-    padding: 10px 20px 10px 10px;
+    padding: 10px 20px;
     text-align: right;
     border-radius: 0 0 5px 5px;
   }

--- a/tests/index.js
+++ b/tests/index.js
@@ -197,4 +197,12 @@ describe('dialog', () => {
     });
     expect($('.rc-dialog-wrap')[0].parentNode.parentNode).to.be(returnedContainer);
   });
+
+  it('render footer padding correctly', () => {
+    async.series([() => {
+      ReactDOM.render(<DialogWrap footer={''} />, container)
+    }, () => {
+      expect($('.rc-dialog-footer').css('padding')).to.be('10px 20px');
+    }]);
+  });
 });


### PR DESCRIPTION
the footer container should align with `title` and `body`, but actually users have to set extra padding style for the container manually at present.