### PR TITLE
Export Dialog component without container wrapper

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 'use strict';
 
 module.exports = require('./src/DialogWrap');
+module.exports.Dialog = require('./src/Dialog');

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -365,6 +365,14 @@ export default class Dialog extends React.Component<IDialogPropTypes, any> {
     (this as any)[name] = node;
   }
 
+  saveWrapRef = (node: any) => {
+    this.saveRef('wrap')(node);
+
+    if (this.wrap && !this.props.visible) {
+      this.wrap.style.display = 'none';
+    }
+  }
+
   render() {
     const { props } = this;
     const { prefixCls, maskClosable } = props;
@@ -381,7 +389,7 @@ export default class Dialog extends React.Component<IDialogPropTypes, any> {
           tabIndex={-1}
           onKeyDown={this.onKeyDown}
           className={`${prefixCls}-wrap ${props.wrapClassName || ''}`}
-          ref={this.saveRef('wrap')}
+          ref={this.saveWrapRef}
           onClick={maskClosable ? this.onMaskClick : undefined}
           role="dialog"
           aria-labelledby={props.title ? this.titleId : null}


### PR DESCRIPTION
• Fixed bug with showing empty wrap `div` element when prop `visible=true`

• Exported Dialog component without container wrapper 
Maybe we can give better name or export from not the index.js file
Related issue: #81 
