### PR TITLE
fix forceRender dom render warning

### DIFF
--- a/src/LazyRenderBox.tsx
+++ b/src/LazyRenderBox.tsx
@@ -18,14 +18,11 @@ export default class LazyRenderBox extends React.Component<ILazyRenderBoxPropTyp
     return !!nextProps.hiddenClassName || !!nextProps.visible;
   }
   render() {
-    let className = this.props.className;
-    if (!!this.props.hiddenClassName && !this.props.visible) {
-      className += ` ${this.props.hiddenClassName}`;
+    const { className, hiddenClassName, visible, forceRender, ...restProps } = this.props;
+    let useClassName = className;
+    if (!!hiddenClassName && !visible) {
+      useClassName += ` ${this.props.hiddenClassName}`;
     }
-    const props: any = { ...this.props };
-    delete props.hiddenClassName;
-    delete props.visible;
-    props.className = className;
-    return <div {...props} />;
+    return <div {...restProps} className={useClassName} />;
   }
 }


### PR DESCRIPTION
forceRender 不渲染到dom上

> index.js:2177 Warning: React does not recognize the `forceRender` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `forcerender` instead. If you accidentally passed it from a parent component, remove it from the DOM element.