### PR TITLE
fix: svg-sprite-loader exception for "npm start" and bootstrap example

### DIFF
--- a/examples/bootstrap.tsx
+++ b/examples/bootstrap.tsx
@@ -64,6 +64,14 @@ class MyControl extends React.Component {
             egestas eget quam. Morbi leo risus, porta ac consectetur ac,
             vestibulum at eros.
           </p>
+          <p>
+            <button type="button" className="btn btn-primary">Primary</button>{' '}
+            <button type="button" className="btn btn-secondary">Secondary</button>{' '}
+            <button type="button" className="btn btn-success">Success</button>{' '}
+            <button type="button" className="btn btn-danger">Danger</button>{' '}
+            <button type="button" className="btn btn-warning">Warning</button>{' '}
+            <button type="button" className="btn btn-info">Info</button>{' '}
+          </p>
           <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus
             sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.
           </p>

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/react-dom": "^16.0.2",
     "async": "^0.9.0",
     "bluebird": "~3.5.3",
-    "bootstrap": "^3.3.6",
+    "bootstrap": "^4.3.1",
     "core-js": "^2.5.1",
     "expect.js": "~0.3.1",
     "jquery": "^3.3.1",


### PR DESCRIPTION
Update bootstrap version to fix the error `Module build failed: ExtractPluginMissingException: svg-sprite-loader exception. svg-sprite-loader in extract mode requires the corresponding plugin`.

Fixes #99, and I also got the same error when running development preview via `npm start`. That is also fixes by this PR.

I also added Bootstrap-styled components (buttons) to illustrate the Bootstrap theming (and to test if example now correctly includes Bootstrap CSS)

