### PR TITLE
feat: class name for root node

### DIFF
--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -408,7 +408,7 @@ export default class Dialog extends React.Component<IDialogChildProps, any> {
       style.display = null;
     }
     return (
-      <div>
+      <div className={`${prefixCls}-root`}>
         {this.getMaskElement()}
         <div
           tabIndex={-1}

--- a/tests/index.js
+++ b/tests/index.js
@@ -98,6 +98,13 @@ describe('dialog', () => {
     expect($('.rc-dialog-mask').length).to.be(1);
   });
 
+  it('root', () => {
+    dialog.setState({
+      visible: true,
+    });
+    expect($('.rc-dialog-root').length).to.be(1);
+  });
+
   it('click close', (finish) => {
     async.series([(done) => {
       dialog.setState({


### PR DESCRIPTION
Root node was previously an empty <div>. It now gets its own (prefixed) class name, which is by default "rc-dialog-root". I need this for be able to reliably grab those root nodes in DOM (force stacking context for correct mask rendering with nested modals in ant-design)

Note: I first chose "<prefix>-container", but since "container" is already used as a term (e.g. DialogWrap), i opted for "<prefix>-root"