### PR TITLE
fix: dialog is not visible, when initialize dialog with forceRender a…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
   - hust2012jiangkai@gmail.com
 
 node_js:
-- 6.9.1
+- 10
 
 before_install:
 - |

--- a/examples/ant-design.tsx
+++ b/examples/ant-design.tsx
@@ -31,6 +31,7 @@ class MyControl extends React.Component<any, any> {
   state = {
     visible: false,
     visible2: false,
+    visible3: true,
     width: 600,
     destroyOnClose: false,
     center: false,
@@ -60,6 +61,10 @@ class MyControl extends React.Component<any, any> {
       visible: false,
       visible2: false,
     });
+  }
+
+  onClose3 = (e: React.SyntheticEvent) => {
+    this.setState({ visible3: false });
   }
 
   onDestroyOnCloseChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -145,7 +150,35 @@ class MyControl extends React.Component<any, any> {
         <p>basic modal</p>
         <button onClick={() => {
           this.setState({
+            visible: true,
+            visible2: true,
+            visible3: true,
+          });
+        }}>打开第三个</button>
+        <button onClick={() => {
+          this.setState({
             visible2: false,
+          });
+        }}>关闭当前</button>
+        <button onClick={this.onClose2}>关闭所有</button>
+        <button onClick={this.changeWidth}>change width</button>
+        <button onClick={this.toggleCloseIcon}>
+          use custom icon, is using icon: {this.state.useIcon && 'true' || 'false'}.
+        </button>
+        <div style={{ height: 200 }} />
+      </Dialog>
+    );
+
+    const dialog3 = (
+      <Dialog
+        forceRender
+        visible={this.state.visible3}
+        onClose={this.onClose3}
+      >
+        <p>initialized with forceRender and visbile true</p>
+        <button onClick={() => {
+          this.setState({
+            visible3: false,
           });
         }}>关闭当前</button>
         <button onClick={this.onClose2}>关闭所有</button>
@@ -202,6 +235,7 @@ class MyControl extends React.Component<any, any> {
         </p>
         {dialog}
         {dialog2}
+        {dialog3}
       </div>
     );
   }

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -83,6 +83,9 @@ export default class Dialog extends React.Component<IDialogChildProps, any> {
   componentDidMount() {
     this.componentDidUpdate({});
     // if forceRender is true, set element style display to be none;
+    if (this.props.forceRender && this.props.visible) {
+      return;
+    }
     if (
       (this.props.forceRender || (this.props.getContainer === false && !this.props.visible)) &&
       this.wrap

--- a/tests/index.js
+++ b/tests/index.js
@@ -432,4 +432,34 @@ describe('dialog', () => {
     expect($('.rc-dialog-wrap').css("zIndex")).to.be('1000');
 
   });
+
+  it('should show dialog when initialize dialog, given forceRender and visible is true', () => {
+    class DialogWrap extends React.Component {
+      state = {
+        visible: true,
+        forceRender: true,
+      };
+      render() {
+        return (
+          <Dialog
+            forceRender={this.state.forceRender}
+            visible={this.state.visible}
+          />
+        );
+      }
+    }
+    ReactDOM.render((
+      <DialogWrap
+        visible
+        forceRender
+      >
+        <div>Show dialog with forceRender and visible is true</div>
+      </DialogWrap>
+    ),container);
+    setTimeout(() => {
+      expect($('.rc-dialog-wrap').css('display'))
+        .to.be('block');
+      done();
+    }, 10);
+  });
 });


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [ ] 新特性提交
- [x] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] TypeScript 定义更新
- [ ] 包体积优化
- [ ] 性能优化
- [ ] 重构
- [ ] 功能增强
- [ ] 国际化改进
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

[#25999](https://github.com/ant-design/ant-design/issues/25999)

### 💡 需求背景和解决方案

1. 要解决的问题
在使用Dialog时，同时将 `forceRender` 和 `visible` 设为 `true`，则只显示mask，无法正常显示dialog

2. 如何解决
```tsx
componentDidMount() {
   // ...
    if (this.props.forceRender && this.props.visible) {
      return;
    }
    if (
      (this.props.forceRender || (this.props.getContainer === false && !this.props.visible)) &&
      this.wrap
    ) {
        // ....
    }
}
```

### 📝 更新日志怎么写？

| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 | Fix dialog component will only show mask, if initialize a Dialog component with both `forceRender` and `visible` are true           |
| 🇨🇳 中文 | 修复因同时设置 `forceRender` 和 `visible` 为 `true` 而导致的只显示mask，无法正常显示 Dialog 组件问题          |

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供