### PR TITLE
fate: add modalRender

### DIFF
--- a/examples/draggable.tsx
+++ b/examples/draggable.tsx
@@ -1,0 +1,64 @@
+import 'bootstrap/dist/css/bootstrap.css';
+import '../assets/bootstrap.less';
+import * as React from 'react';
+import Draggable from 'react-draggable'; 
+import Dialog from '../src/DialogWrap';
+
+const MyControl = () => {
+  const [visible, setVisible] = React.useState(false);
+  const [disabled, setDisabled] = React.useState(true);
+  const onClick = () => {
+    setVisible(true);
+  }
+
+  const onClose = () => {
+    setVisible(false);
+  }
+
+  return (
+    <div style={{ margin: 20 }}>
+      <p>
+        <button type="button" className="btn btn-primary" onClick={onClick}>show dialog</button>
+      </p>
+      <Dialog
+        visible={visible}
+        animation="slide-fade"
+        maskAnimation="fade"
+        onClose={onClose}
+        style={{ width: 600 }}
+        title={(
+            <div
+                style={{
+                    width: '100%',
+                    cursor: 'pointer',
+                }}
+                onMouseOver={() => {
+                    if (disabled){
+                        setDisabled(false)
+                    }
+                }}
+                onMouseOut={() => {
+                    setDisabled(true)
+                }}
+                // fix eslintjsx-a11y/mouse-events-have-key-events
+                // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/mouse-events-have-key-events.md
+                onFocus={ () => {} }
+                onBlur={ () => {}} 
+                // end 
+            >modal</div>
+        )}
+        modalRender={modal => <Draggable disabled={disabled}>{modal}</Draggable>}
+      >
+          <div
+            style={{
+                height: 200,
+            }}
+          >
+              Day before yesterday I saw a rabbit, and yesterday a deer, and today, you.
+          </div>
+      </Dialog>
+    </div>
+  );
+};
+
+export default MyControl;

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "rc-drawer": "4.1.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "react-draggable": "^4.4.3",
     "typescript": "^3.7.2"
   },
   "typings": "./lib/DialogWrap.d.ts"

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -233,7 +233,7 @@ export default class Dialog extends React.Component<IDialogChildProps, any> {
       bodyProps,
       children,
       destroyOnClose,
-      modalRender = modalNode => modalNode,
+      modalRender,
     } = this.props;
     const dest: any = {};
     if (width !== undefined) {
@@ -313,7 +313,7 @@ export default class Dialog extends React.Component<IDialogChildProps, any> {
           style={sentinelStyle}
           aria-hidden="true"
         />
-        {modalRender(content)}
+        {modalRender ? modalRender(content) : content }
         <div
           tabIndex={0}
           ref={this.saveRef('sentinelEnd')}

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -233,6 +233,7 @@ export default class Dialog extends React.Component<IDialogChildProps, any> {
       bodyProps,
       children,
       destroyOnClose,
+      modalRender = modalNode => modalNode,
     } = this.props;
     const dest: any = {};
     if (width !== undefined) {
@@ -276,6 +277,22 @@ export default class Dialog extends React.Component<IDialogChildProps, any> {
       );
     }
 
+    const content = (
+      <div className={`${prefixCls}-content`}>
+        {closer}
+        {headerNode}
+        <div
+          className={`${prefixCls}-body`}
+          style={bodyStyle}
+          ref={this.saveRef('body')}
+          {...bodyProps}
+        >
+          {children}
+        </div>
+        {footerNode}
+      </div>
+    )
+
     const styleBox = { ...style, ...dest };
     const sentinelStyle = { width: 0, height: 0, overflow: 'hidden', outline: 'none' };
     const transitionName = this.getTransitionName();
@@ -296,19 +313,7 @@ export default class Dialog extends React.Component<IDialogChildProps, any> {
           style={sentinelStyle}
           aria-hidden="true"
         />
-        <div className={`${prefixCls}-content`}>
-          {closer}
-          {headerNode}
-          <div
-            className={`${prefixCls}-body`}
-            style={bodyStyle}
-            ref={this.saveRef('body')}
-            {...bodyProps}
-          >
-            {children}
-          </div>
-          {footerNode}
-        </div>
+        {modalRender(content)}
         <div
           tabIndex={0}
           ref={this.saveRef('sentinelEnd')}

--- a/src/IDialogPropTypes.tsx
+++ b/src/IDialogPropTypes.tsx
@@ -37,6 +37,7 @@ export interface IDialogPropTypes {
   wrapProps?: any;
   getContainer?: IStringOrHtmlElement | (() => IStringOrHtmlElement) | false;
   closeIcon?: ReactNode;
+  modalRender?: (node: ReactNode) => ReactNode;
   forceRender?: boolean;
   // https://github.com/ant-design/ant-design/issues/19771
   // https://github.com/react-component/dialog/issues/95

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-render-return-value */
 /* eslint-disable func-names */
-import React from 'react';
+import React, { cloneElement } from 'react';
 import { mount } from 'enzyme';
 
 import KeyCode from 'rc-util/lib/KeyCode';
@@ -50,7 +50,7 @@ describe('dialog', () => {
     dialog.unmount();
     jest.useRealTimers();
   });
-
+  
   it('show', () => {
     dialog.setState({ visible: true });
     jest.runAllTimers();
@@ -424,5 +424,17 @@ describe('dialog', () => {
     jest.runAllTimers();
     d.update();
     expect(d.find('.rc-dialog-wrap').props().style.display).toEqual(null);
+  });
+
+  it('modalRender', () => {
+    const modalRender = mount(
+      <DialogWrap modalRender={node => cloneElement(node, { ...node.props, style: { background: '#1890ff' }})}>
+      </DialogWrap>
+    );
+    modalRender.setState({ visible: true });
+    jest.runAllTimers();
+    modalRender.update();
+    expect(modalRender.find('.rc-dialog-content').props().style.background).toEqual('#1890ff');
+    modalRender.unmount();
   });
 });

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -50,7 +50,7 @@ describe('dialog', () => {
     dialog.unmount();
     jest.useRealTimers();
   });
-  
+
   it('show', () => {
     dialog.setState({ visible: true });
     jest.runAllTimers();


### PR DESCRIPTION
### 🤔 这个变动的性质是？

- [x] 新特性提交
- [ ] 日常 bug 修复
- [ ] 站点、文档改进
- [ ] 组件样式改进
- [ ] TypeScript 定义更新
- [ ] 重构
- [x] 代码风格优化
- [x] 测试用例
- [ ] 分支合并
- [ ] 其他改动（是关于什么的改动？）

### 🔗 相关 Issue

https://github.com/ant-design/ant-design/issues/16613
https://github.com/ant-design/ant-design/issues/13230
https://github.com/ant-design/ant-design/issues/4617
https://github.com/ant-design/ant-design/issues/374

### 💡 需求背景和解决方案

添加Modal组件框的body可自定义。这样可以方便的重写body, 来进行自定义拖拽，或者最大化，最小化等功能

### 📝 更新日志怎么写？


| 语言    | 更新描述 |
| ------- | -------- |
| 🇺🇸 英文 |          |
| 🇨🇳 中文 |     添加一个modalRender 属性     |

### ☑️ 请求合并前的自查清单

> 请自检并全部勾选上

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
