### PR TITLE
fix: trigger close only when click wrap itself

### DIFF
--- a/src/Dialog/Content/index.tsx
+++ b/src/Dialog/Content/index.tsx
@@ -18,7 +18,6 @@ export interface ContentProps extends IDialogChildProps {
 
 export interface ContentRef {
   focus: () => void;
-  getDOM: () => HTMLDivElement;
   changeActive: (next: boolean) => void;
 }
 
@@ -58,7 +57,6 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
     focus: () => {
       sentinelStartRef.current?.focus();
     },
-    getDOM: () => dialogRef.current,
     changeActive: (next) => {
       const { activeElement } = document;
       if (next && activeElement === sentinelEndRef.current) {

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -112,7 +112,7 @@ export default function Dialog(props: IDialogChildProps) {
       if(contentClickRef.current) {
         contentClickRef.current = false;
       } else if (
-        !contains(contentRef.current.getDOM(), e.target as HTMLElement)
+        wrapperRef.current === e.target
       ) {
         onInternalClose(e);
       }


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/28353
fix https://github.com/ant-design/ant-design/issues/28399

在 https://github.com/ant-design/ant-design/issues/28353 中，点击 label 中的元素，label 会连续触发两次点击事件，冒泡到父级弹窗的时候，由于父子弹窗没有包含的关系，就会触发父级的关闭事件。

在 https://github.com/ant-design/ant-design/issues/28399 是因为在下拉框中的触发点击事件，冒泡了上来，但是下拉框和弹窗没有包含关系，也会触发关闭事件。

https://github.com/react-component/dialog/blob/4c3b871feb8549fb46413bc7be7460da8a779e8a/src%2FDialog%2Findex.tsx#L115 这里的逻辑其实就是只要不是点击的内容就触发关闭，在弹窗中 wrap 是撑满屏幕，不点击内容就是点击 wrap 本身，刚好规避了上述两种特殊情况

@zombieJ 评估一下，有没有副作用。