### PR TITLE
fix: destroyOnClose fails with forceRender

### DIFF
--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -14,13 +14,21 @@ import { IDialogPropTypes } from './IDialogPropTypes';
 
 const DialogWrap: React.FC<IDialogPropTypes> = (props: IDialogPropTypes) => {
   const { visible, getContainer, forceRender, destroyOnClose = false, afterClose } = props;
+  const [forceRenderTime, setForceRenderTime] = React.useState<boolean>(forceRender);
   const [animatedVisible, setAnimatedVisible] = React.useState<boolean>(visible);
 
   React.useEffect(() => {
     if (visible) {
       setAnimatedVisible(true);
+      if (destroyOnClose) {
+        setForceRenderTime(false);
+      }
     }
   }, [visible]);
+
+  React.useEffect(() => {
+    setForceRenderTime(forceRender);
+  }, [forceRender]);
 
   // 渲染在当前 dom 里；
   if (getContainer === false) {
@@ -33,15 +41,16 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props: IDialogPropTypes) => {
   }
 
   // Destroy on close will remove wrapped div
-  if (!forceRender && destroyOnClose && !animatedVisible) {
+  if (!forceRenderTime && destroyOnClose && !animatedVisible) {
     return null;
   }
 
   return (
-    <Portal visible={visible} forceRender={forceRender} getContainer={getContainer}>
+    <Portal visible={visible} forceRender={forceRenderTime} getContainer={getContainer}>
       {(childProps: IDialogChildProps) => (
         <Dialog
           {...props}
+          forceRender={forceRenderTime}
           destroyOnClose={destroyOnClose}
           afterClose={() => {
             afterClose?.();

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -113,6 +113,29 @@ describe('dialog', () => {
     });
   });
 
+  it('destroy component when forceRender is true', () => {
+    const wrapper = mount(
+      <Dialog destroyOnClose forceRender>
+        <div>forceRender destroyOnClose</div>
+      </Dialog>,
+    );
+
+    expect(wrapper.find('.rc-dialog-body > div').text()).toEqual('forceRender destroyOnClose');
+
+    // Hide
+    wrapper.setProps({ visible: true });
+    jest.runAllTimers();
+    wrapper.update();
+
+    // Show
+    wrapper.setProps({ visible: false });
+    jest.runAllTimers();
+    wrapper.update();
+
+    expect(wrapper.find('.rc-dialog-body > div')).toHaveLength(0);
+    wrapper.unmount();
+  });
+
   it('esc to close', () => {
     const onClose = jest.fn();
     const wrapper = mount(<Dialog onClose={onClose} visible />);


### PR DESCRIPTION
ant-design/ant-design#28847

解决`destroyOnClose`和`forceRender`都设置为`true`时`destroyOnClose`失效

**原因：当`forceRender`设置为`true`时，判断是否删除子节点的语句失效**

**方案：为`forceRender`增加一层缓存，当第一次打开`Modal`时设置`forceRender`为`false`**


此外，感觉antd文档里关于`forceRender`部分的描述不是很清晰，个人理解为首次未打开`Modal`可获取其中的dom
![image](https://user-images.githubusercontent.com/44696899/104726516-b59e4680-576e-11eb-832a-710ca9f4bae4.png)

觉得可以和`dialog`的文档稍作同步