### PR TITLE
feat: support data-*

### DIFF
--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -3,6 +3,7 @@ import { useRef, useEffect } from 'react';
 import classNames from 'classnames';
 import KeyCode from 'rc-util/lib/KeyCode';
 import contains from 'rc-util/lib/Dom/contains';
+import pickAttrs from 'rc-util/lib/pickAttrs';
 import type ScollLocker from 'rc-util/lib/Dom/scrollLocker';
 import type { IDialogPropTypes } from '../IDialogPropTypes';
 import Mask from './Mask';
@@ -162,7 +163,7 @@ export default function Dialog(props: IDialogChildProps) {
 
   // ========================= Render =========================
   return (
-    <div className={`${prefixCls}-root`}>
+    <div className={`${prefixCls}-root`} {...pickAttrs(props, { data: true })}>
       <Mask
         prefixCls={prefixCls}
         visible={mask && visible}


### PR DESCRIPTION
通过 cypress 编写测试。页面中存在多个 Drawer 时，通过传递不同的 data-test-id 属性给对应 Drawer 组件，然后通过 data-test-id 可以准确获得对应的 DOM 元素。但是 Modal 组件将 data-test-id 给丢弃了。并没有在 DOM 元素上设置。从而造成不能准确地获取对应的 DOM 元素。

fix https://github.com/ant-design/ant-design/issues/30716