### PR TITLE
feat: CSSMotion bind ref, avoid rc-motion call findDOMNode

### DIFF
--- a/src/Dialog/Mask.tsx
+++ b/src/Dialog/Mask.tsx
@@ -20,8 +20,9 @@ export default function Mask(props: MaskProps) {
       motionName={motionName}
       leavedClassName={`${prefixCls}-mask-hidden`}
     >
-      {({ className: motionClassName, style: motionStyle }) => (
+      {({ className: motionClassName, style: motionStyle }, ref) => (
         <div
+          ref={ref}
           style={{ ...motionStyle, ...style }}
           className={classNames(`${prefixCls}-mask`, motionClassName)}
           {...maskProps}


### PR DESCRIPTION
bind ref to CSSMotion, avoid rc-motion call findDOMNode，need RC release new version about this [pr](https://github.com/react-component/motion/pull/17)
