### PR TITLE
fix: trigger focus after close correctly.

### DIFF
--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -141,6 +141,9 @@ export default function Dialog(props: IDialogChildProps) {
   useEffect(() => {
     if (visible) {
       setAnimatedVisible(true);
+      if (!contains(wrapperRef.current, document.activeElement)) {
+        lastOutSideActiveElementRef.current = document.activeElement as HTMLElement;
+      }
     }
     return () => {};
   }, [visible]);


### PR DESCRIPTION
fix a issue of Ant-Design -- Modal.method() not trigger focus after close. https://github.com/ant-design/ant-design/issues/32923