### PR TITLE
fix uuid when test

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -9,7 +9,9 @@ export function getMotionName(prefixCls: string, transitionName?: string, animat
 
 // ================================ UUID ================================
 let uuid = -1;
+const isTest = process.env.NODE_ENV === 'test';
 export function getUUID() {
+  if (isTest) return 0;
   uuid += 1;
   return uuid;
 }


### PR DESCRIPTION
How about fixing the UUID by referring to NODE_ENV?

In my test environment, import this only once (via antd), so the snapshot test will show the difference.

<img width="494" alt="スクリーンショット 2022-02-25 6 51 20" src="https://user-images.githubusercontent.com/20538481/155615000-dabdfcfa-7888-4e25-bd78-482385763ff0.png">

