### PR TITLE
Fixes accessibility issue created by incorrect dialog role

### DIFF
--- a/src/Dialog/Content/index.tsx
+++ b/src/Dialog/Content/index.tsx
@@ -142,6 +142,7 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
         <div
           key="dialog-element"
           role="dialog"
+          aria-modal="true"
           ref={motionRef}
           style={{ ...motionStyle, ...style, ...contentStyle }}
           className={classNames(prefixCls, className, motionClassName)}

--- a/src/Dialog/Content/index.tsx
+++ b/src/Dialog/Content/index.tsx
@@ -14,12 +14,12 @@ export type ContentProps = {
   onVisibleChanged: (visible: boolean) => void;
   onMouseDown: React.MouseEventHandler;
   onMouseUp: React.MouseEventHandler;
-} & IDialogChildProps
+} & IDialogChildProps;
 
 export type ContentRef = {
   focus: () => void;
   changeActive: (next: boolean) => void;
-}
+};
 
 const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
   const {
@@ -141,7 +141,7 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
       {({ className: motionClassName, style: motionStyle }, motionRef) => (
         <div
           key="dialog-element"
-          role="document"
+          role="dialog"
           ref={motionRef}
           style={{ ...motionStyle, ...style, ...contentStyle }}
           className={classNames(prefixCls, className, motionClassName)}

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -184,7 +184,6 @@ export default function Dialog(props: IDialogChildProps) {
         className={classNames(`${prefixCls}-wrap`, wrapClassName)}
         ref={wrapperRef}
         onClick={onWrapperClick}
-        role="dialog"
         aria-labelledby={title ? ariaIdRef.current : null}
         style={{ zIndex, ...wrapStyle, display: !animatedVisible ? 'none' : null }}
         {...wrapProps}

--- a/tests/__snapshots__/index.spec.tsx.snap
+++ b/tests/__snapshots__/index.spec.tsx.snap
@@ -9,13 +9,12 @@ exports[`dialog add rootClassName should render correct 1`] = `
   />
   <div
     class="rc-dialog-wrap"
-    role="dialog"
     style="font-size: 10px;"
     tabindex="-1"
   >
     <div
       class="rc-dialog"
-      role="document"
+      role="dialog"
       style="width: 600px; height: 903px;"
     >
       <div
@@ -58,12 +57,11 @@ exports[`dialog should render correct 1`] = `
   />
   <div
     class="rc-dialog-wrap"
-    role="dialog"
     tabindex="-1"
   >
     <div
       class="rc-dialog"
-      role="document"
+      role="dialog"
     >
       <div
         aria-hidden="true"

--- a/tests/__snapshots__/index.spec.tsx.snap
+++ b/tests/__snapshots__/index.spec.tsx.snap
@@ -13,9 +13,9 @@ exports[`dialog add rootClassName should render correct 1`] = `
     tabindex="-1"
   >
     <div
+      aria-modal="true"
       class="rc-dialog"
       role="dialog"
-      aria-modal="true"
       style="width: 600px; height: 903px;"
     >
       <div
@@ -61,9 +61,9 @@ exports[`dialog should render correct 1`] = `
     tabindex="-1"
   >
     <div
+      aria-modal="true"
       class="rc-dialog"
       role="dialog"
-      aria-modal="true"
     >
       <div
         aria-hidden="true"

--- a/tests/__snapshots__/index.spec.tsx.snap
+++ b/tests/__snapshots__/index.spec.tsx.snap
@@ -15,6 +15,7 @@ exports[`dialog add rootClassName should render correct 1`] = `
     <div
       class="rc-dialog"
       role="dialog"
+      aria-modal="true"
       style="width: 600px; height: 903px;"
     >
       <div
@@ -62,6 +63,7 @@ exports[`dialog should render correct 1`] = `
     <div
       class="rc-dialog"
       role="dialog"
+      aria-modal="true"
     >
       <div
         aria-hidden="true"


### PR DESCRIPTION
### Issue
Dialog's boundaries are not communicated because of improper structure.

### User Impact
When this is not done, it is unclear to screen readers when they are leaving or entering a dialog when using the virtual cursor.

### Compliant Code Example
https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html

### Additional Details
`Role=document` does not need to be used. `role=dialog` should be moved to where your `role=document` was.