### PR TITLE
fix: transformOrigin calculated by mousePosition  on React 18

### DIFF
--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -5,6 +5,7 @@ import KeyCode from 'rc-util/lib/KeyCode';
 import useId from 'rc-util/lib/hooks/useId';
 import contains from 'rc-util/lib/Dom/contains';
 import pickAttrs from 'rc-util/lib/pickAttrs';
+import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
 import type ScollLocker from 'rc-util/lib/Dom/scrollLocker';
 import type { IDialogPropTypes } from '../IDialogPropTypes';
 import Mask from './Mask';
@@ -136,7 +137,7 @@ export default function Dialog(props: IDialogChildProps) {
   }
 
   // ========================= Effect =========================
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (visible) {
       setAnimatedVisible(true);
     }

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -6,7 +6,6 @@ import useId from 'rc-util/lib/hooks/useId';
 import contains from 'rc-util/lib/Dom/contains';
 import pickAttrs from 'rc-util/lib/pickAttrs';
 import useLayoutEffect from 'rc-util/lib/hooks/useLayoutEffect';
-import type ScollLocker from 'rc-util/lib/Dom/scrollLocker';
 import type { IDialogPropTypes } from '../IDialogPropTypes';
 import Mask from './Mask';
 import { getMotionName } from '../util';


### PR DESCRIPTION
在React 18中第一次打开可以正确地从按钮位置展开弹出框，但是第二次之后则从错误的位置展开。

Ant Design的Modal也受到影响：[CodeSandbox](https://codesandbox.io/s/react-18-antd-modal-zhan-kai-wei-zhi-cuo-wu-xgcvj0?file=/index.js)

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/5997870/180611980-4e535d5a-20ed-46b1-a8e1-96550dd23eed.gif)

close https://github.com/ant-design/ant-design/issues/36911
close https://github.com/ant-design/ant-design/issues/38232


