### PR TITLE
feat: Support document.activeElement

### DIFF
--- a/src/Dialog/Content/Panel.tsx
+++ b/src/Dialog/Content/Panel.tsx
@@ -4,6 +4,7 @@ import MemoChildren from './MemoChildren';
 import type { IDialogPropTypes } from '../../IDialogPropTypes';
 
 const sentinelStyle = { width: 0, height: 0, overflow: 'hidden', outline: 'none' };
+const entityStyle = { outline: 'none' };
 
 export interface PanelProps extends Omit<IDialogPropTypes, 'getOpenCount'> {
   prefixCls: string;
@@ -45,10 +46,11 @@ const Panel = React.forwardRef<ContentRef, PanelProps>((props, ref) => {
   // ================================= Refs =================================
   const sentinelStartRef = useRef<HTMLDivElement>();
   const sentinelEndRef = useRef<HTMLDivElement>();
+  const entityRef = useRef<HTMLDivElement>();
 
   React.useImperativeHandle(ref, () => ({
     focus: () => {
-      sentinelStartRef.current?.focus();
+      entityRef.current?.focus();
     },
     changeActive: (next) => {
       const { activeElement } = document;
@@ -122,9 +124,11 @@ const Panel = React.forwardRef<ContentRef, PanelProps>((props, ref) => {
       onMouseUp={onMouseUp}
     >
       <div tabIndex={0} ref={sentinelStartRef} style={sentinelStyle} aria-hidden="true" />
-      <MemoChildren shouldUpdate={visible || forceRender}>
-        {modalRender ? modalRender(content) : content}
-      </MemoChildren>
+      <div ref={entityRef} tabIndex={-1} style={entityStyle}>
+        <MemoChildren shouldUpdate={visible || forceRender}>
+          {modalRender ? modalRender(content) : content}
+        </MemoChildren>
+      </div>
       <div tabIndex={0} ref={sentinelEndRef} style={sentinelStyle} aria-hidden="true" />
     </div>
   );

--- a/tests/__snapshots__/index.spec.tsx.snap
+++ b/tests/__snapshots__/index.spec.tsx.snap
@@ -24,20 +24,25 @@ exports[`dialog add rootClassName should render correct 1`] = `
         tabindex="0"
       />
       <div
-        class="rc-dialog-content"
+        style="outline: none;"
+        tabindex="-1"
       >
-        <button
-          aria-label="Close"
-          class="rc-dialog-close"
-          type="button"
-        >
-          <span
-            class="rc-dialog-close-x"
-          />
-        </button>
         <div
-          class="rc-dialog-body"
-        />
+          class="rc-dialog-content"
+        >
+          <button
+            aria-label="Close"
+            class="rc-dialog-close"
+            type="button"
+          >
+            <span
+              class="rc-dialog-close-x"
+            />
+          </button>
+          <div
+            class="rc-dialog-body"
+          />
+        </div>
       </div>
       <div
         aria-hidden="true"
@@ -72,30 +77,35 @@ exports[`dialog should render correct 1`] = `
         tabindex="0"
       />
       <div
-        class="rc-dialog-content"
+        style="outline: none;"
+        tabindex="-1"
       >
-        <button
-          aria-label="Close"
-          class="rc-dialog-close"
-          type="button"
-        >
-          <span
-            class="rc-dialog-close-x"
-          />
-        </button>
         <div
-          class="rc-dialog-header"
+          class="rc-dialog-content"
         >
-          <div
-            class="rc-dialog-title"
-            id="test-id"
+          <button
+            aria-label="Close"
+            class="rc-dialog-close"
+            type="button"
           >
-            Default
+            <span
+              class="rc-dialog-close-x"
+            />
+          </button>
+          <div
+            class="rc-dialog-header"
+          >
+            <div
+              class="rc-dialog-title"
+              id="test-id"
+            >
+              Default
+            </div>
           </div>
+          <div
+            class="rc-dialog-body"
+          />
         </div>
-        <div
-          class="rc-dialog-body"
-        />
       </div>
       <div
         aria-hidden="true"

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -232,19 +232,28 @@ describe('dialog', () => {
     expect(document.querySelector('input')).toHaveFocus();
   });
 
+  it('focus content', () => {
+    const wrapper = mount(<Dialog visible />, { attachTo: document.body });
+    const content = document.querySelector(
+      '.rc-dialog > div:first-child + div',
+    ) as unknown as HTMLDivElement;
+    expect(document.activeElement).toBe(content);
+    wrapper.unmount();
+  });
+
   describe('Tab should keep focus in dialog', () => {
     it('basic tabbing', () => {
       const wrapper = mount(<Dialog visible />, { attachTo: document.body });
-      const sentinelEnd = document.querySelectorAll(
-        '.rc-dialog-content + div',
-      )[0] as unknown as HTMLDivElement;
+      const sentinelEnd = document.querySelector(
+        '.rc-dialog > div:last-child',
+      ) as unknown as HTMLDivElement;
       sentinelEnd.focus();
 
       wrapper.find('.rc-dialog-wrap').simulate('keyDown', {
         keyCode: KeyCode.TAB,
       });
 
-      const sentinelStart = document.querySelectorAll('.rc-dialog > div')[0];
+      const sentinelStart = document.querySelector('.rc-dialog > div:first-child');
       expect(document.activeElement).toBe(sentinelStart);
 
       wrapper.unmount();
@@ -252,11 +261,16 @@ describe('dialog', () => {
 
     it('trap focus after shift-tabbing', () => {
       const wrapper = mount(<Dialog visible />, { attachTo: document.body });
+      const sentinelStart = document.querySelector(
+        '.rc-dialog > div:first-child',
+      ) as unknown as HTMLDivElement;
+      sentinelStart.focus();
+
       wrapper.find('.rc-dialog-wrap').simulate('keyDown', {
         keyCode: KeyCode.TAB,
         shiftKey: true,
       });
-      const sentinelEnd = document.querySelectorAll('.rc-dialog-content + div')[0];
+      const sentinelEnd = document.querySelector('.rc-dialog > div:last-child');
       expect(document.activeElement).toBe(sentinelEnd);
 
       wrapper.unmount();


### PR DESCRIPTION
支持`document.activeElement`获取到`dialog`组件的内容，而不是一个空的div。
https://github.com/ant-design/ant-design/issues/40380

使用一个div包裹`dialog`组件的内容，并使div聚焦，从而使div包含内容，而不是一个空的div。