### PR TITLE
fix: invalid autofocus

### DIFF
--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -41,7 +41,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props: IDialogPropTypes) => {
     <Portal
       open={visible || forceRender || animatedVisible}
       autoDestroy={false}
-      getContainer={getContainer}
+      getContainer={getContainer || 'body'}
       autoLock={visible || animatedVisible}
     >
       <Dialog

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -222,8 +222,7 @@ describe('dialog', () => {
     expect(wrapper.find('.rc-dialog-footer').text()).toBe('test');
   });
 
-  // 失效了，需要修复
-  it.skip('support input autoFocus', () => {
+  it('support input autoFocus', () => {
     render(
       <Dialog visible>
         <input autoFocus />


### PR DESCRIPTION
fix https://github.com/ant-design/ant-design/issues/41239
react中的`autoFocus`似乎是react模拟的，并非原生的autofocus。https://github.com/facebook/react/blob/main/packages/react-dom-bindings/src/client/ReactDOMHostConfig.js#L522-L528
`rc-potral`的挂载点似乎不太稳定，有可能虚拟dom渲染的时候挂载点还没添加到页面，或者添加后又被移除（`visible`为false的情况），`autofocus`失效。