### PR TITLE
feat: add props for dialog content element

### DIFF
--- a/src/Dialog/Content/Panel.tsx
+++ b/src/Dialog/Content/Panel.tsx
@@ -34,6 +34,7 @@ const Panel = React.forwardRef<ContentRef, PanelProps>((props, ref) => {
     children,
     bodyStyle,
     bodyProps,
+    contentClassName,
     contentProps,
     modalRender,
     onMouseDown,
@@ -103,7 +104,7 @@ const Panel = React.forwardRef<ContentRef, PanelProps>((props, ref) => {
   }
 
   const content = (
-    <div className={`${prefixCls}-content`} {...contentProps}>
+    <div className={classNames(`${prefixCls}-content`, contentClassName)} {...contentProps}>
       {closer}
       {headerNode}
       <div className={`${prefixCls}-body`} style={bodyStyle} {...bodyProps}>

--- a/src/Dialog/Content/Panel.tsx
+++ b/src/Dialog/Content/Panel.tsx
@@ -34,6 +34,7 @@ const Panel = React.forwardRef<ContentRef, PanelProps>((props, ref) => {
     children,
     bodyStyle,
     bodyProps,
+    contentProps,
     modalRender,
     onMouseDown,
     onMouseUp,
@@ -102,7 +103,7 @@ const Panel = React.forwardRef<ContentRef, PanelProps>((props, ref) => {
   }
 
   const content = (
-    <div className={`${prefixCls}-content`}>
+    <div className={`${prefixCls}-content`} {...contentProps}>
       {closer}
       {headerNode}
       <div className={`${prefixCls}-body`} style={bodyStyle} {...bodyProps}>

--- a/src/IDialogPropTypes.tsx
+++ b/src/IDialogPropTypes.tsx
@@ -32,6 +32,7 @@ export type IDialogPropTypes = {
   width?: string | number;
   height?: string | number;
   zIndex?: number;
+  contentClassName?: string;
   bodyProps?: any;
   contentProps?: any;
   maskProps?: any;

--- a/src/IDialogPropTypes.tsx
+++ b/src/IDialogPropTypes.tsx
@@ -33,6 +33,7 @@ export type IDialogPropTypes = {
   height?: string | number;
   zIndex?: number;
   bodyProps?: any;
+  contentProps?: any;
   maskProps?: any;
   rootClassName?: string;
   wrapProps?: any;


### PR DESCRIPTION
目前只能给 `-body` 这一层加 style，设置出来的 backgrond-color 有 padding.
无法满足加样式在 `-content` 这层上，所以提此 PR
![image](https://github.com/react-component/dialog/assets/19547819/2ca383c6-023c-4420-9699-5417c84bf7f1)
