### PR TITLE
Update mousePosition check

### DIFF
--- a/src/Dialog/Content/index.tsx
+++ b/src/Dialog/Content/index.tsx
@@ -41,7 +41,7 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
     const elementOffset = offset(dialogRef.current);
 
     setTransformOrigin(
-      mousePosition
+      (mousePosition?.x && mousePosition?.y)
         ? `${mousePosition.x - elementOffset.left}px ${mousePosition.y - elementOffset.top}px`
         : '',
     );


### PR DESCRIPTION
This updates the mousePostion check for the transform-origin calculation.

In some rare cases, e.g. in a TestEnvironment (react-testing-library with Jest) the mousePosition can look like this:

```js
{
  x: undefined,
  y : undefined
}
```

which leads to `transform-origin: NaNpx NaNpx;` in the element itself.

This check fixes this issue.