### PR TITLE
docs(type): supplement classnames and styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ ReactDOM.render(
 | ---------------------- | ------------------------------ | --------- | ------------------------------------------------------------------------------- | ------- |
 | prefixCls              | String                         | rc-dialog | The dialog dom node's prefixCls                                                 |         |
 | className              | String                         |           | additional className for dialog                                                 |         |
-| classNames             | { mask?: string; wrapper?: string; header?: string; body?: string; footer?: string} |           | pass className to target area |         |
-| styles                 | { mask?: CSSProperties; wrapper?: CSSProperties; header?: CSSProperties; body?: CSSProperties; footer?: CSSProperties} |    | pass styles to target area |         |
+| classNames             | { header?: string; body?: string; footer?: string; mask?: string; content?: string; wrapper?: string;  } |           | pass className to target area |         |
+| styles                 | { header?: CSSProperties; body?: CSSProperties; footer?: CSSProperties; mask?: CSSProperties; content?: CSSProperties; wrapper?: CSSProperties;  } |    | pass styles to target area |         |
 | style                  | Object                         | {}        | Root style for dialog element.Such as width, height                             |         |
 | zIndex                 | Number                         |           |                                                                                 |         |
 | visible                | Boolean                        | false     | current dialog's visible status                                                 |         |


### PR DESCRIPTION
classnames and styles 目前都是支持这六个的，补充缺失的content，按照ts类型的顺序重新排序了文档中的顺序，方便检查。

<img width="358" alt="image" src="https://github.com/user-attachments/assets/9a9387da-3c72-480c-b2ee-187d2afdb6c3">
<img width="496" alt="image" src="https://github.com/user-attachments/assets/cb69df48-3bfb-49d4-9d7f-e2410c6f1d55">
<img width="449" alt="image" src="https://github.com/user-attachments/assets/b6188155-e4c1-4e89-8fa3-1c3e485cf2d5">
