### PR TITLE
fix: Avoid using aria-hidden on a focused element

### DIFF
--- a/src/Dialog/Content/Panel.tsx
+++ b/src/Dialog/Content/Panel.tsx
@@ -121,11 +121,11 @@ const Panel = React.forwardRef<ContentRef, PanelProps>((props, ref) => {
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
     >
-      <div tabIndex={0} ref={sentinelStartRef} style={sentinelStyle} aria-hidden="true" />
+      <div tabIndex={0} ref={sentinelStartRef} style={sentinelStyle} />
       <MemoChildren shouldUpdate={visible || forceRender}>
         {modalRender ? modalRender(content) : content}
       </MemoChildren>
-      <div tabIndex={0} ref={sentinelEndRef} style={sentinelStyle} aria-hidden="true" />
+      <div tabIndex={0} ref={sentinelEndRef} style={sentinelStyle} />
     </div>
   );
 });

--- a/tests/__snapshots__/index.spec.tsx.snap
+++ b/tests/__snapshots__/index.spec.tsx.snap
@@ -19,7 +19,6 @@ exports[`dialog add rootClassName should render correct 1`] = `
       style="width: 600px; height: 903px;"
     >
       <div
-        aria-hidden="true"
         style="width: 0px; height: 0px; overflow: hidden; outline: none;"
         tabindex="0"
       />
@@ -40,7 +39,6 @@ exports[`dialog add rootClassName should render correct 1`] = `
         />
       </div>
       <div
-        aria-hidden="true"
         style="width: 0px; height: 0px; overflow: hidden; outline: none;"
         tabindex="0"
       />
@@ -67,7 +65,6 @@ exports[`dialog should render correct 1`] = `
       role="dialog"
     >
       <div
-        aria-hidden="true"
         style="width: 0px; height: 0px; overflow: hidden; outline: none;"
         tabindex="0"
       />
@@ -98,7 +95,6 @@ exports[`dialog should render correct 1`] = `
         />
       </div>
       <div
-        aria-hidden="true"
         style="width: 0px; height: 0px; overflow: hidden; outline: none;"
         tabindex="0"
       />


### PR DESCRIPTION
close https://github.com/ant-design/ant-design/issues/50170

Blocked aria-hidden on a `<div>` element because the element that just received focus must not be hidden from assistive technology users. Avoid using aria-hidden on a focused element or its ancestor. Consider using the inert attribute instead, which will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at https://w3c.github.io/aria/#aria-hidden. `<div tabindex=​"0" aria-hidden=​"true" style=​"width:​ 0px;​ height:​ 0px;​ overflow:​ hidden;​ outline:​ none;​">​</div>`

看了下 MUI 也没有加 `aria-hidden`。​

<img width="561" alt="截屏2024-08-01 23 23 25" src="https://github.com/user-attachments/assets/459b6477-7e49-40db-9ce8-e14f9cddb53b">
