### PR TITLE
fix: Avoid using aria-hidden on a focused element

### DIFF
--- a/src/Dialog/Content/Panel.tsx
+++ b/src/Dialog/Content/Panel.tsx
@@ -55,11 +55,10 @@ const Panel = React.forwardRef<ContentRef, PanelProps>((props, ref) => {
 
   const sentinelStartRef = useRef<HTMLDivElement>();
   const sentinelEndRef = useRef<HTMLDivElement>();
-  const entityRef = useRef<HTMLDivElement>();
 
   React.useImperativeHandle(ref, () => ({
     focus: () => {
-      entityRef.current?.focus({ preventScroll: true });
+      sentinelStartRef.current?.focus({ preventScroll: true });
     },
     changeActive: (next) => {
       const { activeElement } = document;
@@ -157,13 +156,12 @@ const Panel = React.forwardRef<ContentRef, PanelProps>((props, ref) => {
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
     >
-      <div tabIndex={0} ref={sentinelStartRef} style={sentinelStyle} aria-hidden="true" />
-      <div ref={entityRef} tabIndex={-1} style={entityStyle}>
+      <div ref={sentinelStartRef} tabIndex={0} style={entityStyle}>
         <MemoChildren shouldUpdate={visible || forceRender}>
           {modalRender ? modalRender(content) : content}
         </MemoChildren>
       </div>
-      <div tabIndex={0} ref={sentinelEndRef} style={sentinelStyle} aria-hidden="true" />
+      <div tabIndex={0} ref={sentinelEndRef} style={sentinelStyle} />
     </div>
   );
 });

--- a/tests/__snapshots__/index.spec.tsx.snap
+++ b/tests/__snapshots__/index.spec.tsx.snap
@@ -19,13 +19,8 @@ exports[`dialog add rootClassName should render correct 1`] = `
       style="width: 600px; height: 903px;"
     >
       <div
-        aria-hidden="true"
-        style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-        tabindex="0"
-      />
-      <div
         style="outline: none;"
-        tabindex="-1"
+        tabindex="0"
       >
         <div
           class="rc-dialog-content"
@@ -45,7 +40,6 @@ exports[`dialog add rootClassName should render correct 1`] = `
         </div>
       </div>
       <div
-        aria-hidden="true"
         style="width: 0px; height: 0px; overflow: hidden; outline: none;"
         tabindex="0"
       />
@@ -72,13 +66,8 @@ exports[`dialog should render correct 1`] = `
       role="dialog"
     >
       <div
-        aria-hidden="true"
-        style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-        tabindex="0"
-      />
-      <div
         style="outline: none;"
-        tabindex="-1"
+        tabindex="0"
       >
         <div
           class="rc-dialog-content"
@@ -108,7 +97,6 @@ exports[`dialog should render correct 1`] = `
         </div>
       </div>
       <div
-        aria-hidden="true"
         style="width: 0px; height: 0px; overflow: hidden; outline: none;"
         tabindex="0"
       />
@@ -136,13 +124,8 @@ exports[`dialog should support classNames 1`] = `
       style="width: 600px; height: 903px;"
     >
       <div
-        aria-hidden="true"
-        style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-        tabindex="0"
-      />
-      <div
         style="outline: none;"
-        tabindex="-1"
+        tabindex="0"
       >
         <div
           class="rc-dialog-content custom-content"
@@ -177,7 +160,6 @@ exports[`dialog should support classNames 1`] = `
         </div>
       </div>
       <div
-        aria-hidden="true"
         style="width: 0px; height: 0px; overflow: hidden; outline: none;"
         tabindex="0"
       />
@@ -207,13 +189,8 @@ exports[`dialog should support styles 1`] = `
       style="width: 600px; height: 903px;"
     >
       <div
-        aria-hidden="true"
-        style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-        tabindex="0"
-      />
-      <div
         style="outline: none;"
-        tabindex="-1"
+        tabindex="0"
       >
         <div
           class="rc-dialog-content"
@@ -252,7 +229,6 @@ exports[`dialog should support styles 1`] = `
         </div>
       </div>
       <div
-        aria-hidden="true"
         style="width: 0px; height: 0px; overflow: hidden; outline: none;"
         tabindex="0"
       />


### PR DESCRIPTION
和 https://github.com/react-component/dialog/pull/449 类似，不过是在 antd 5.x 中修复，并移除一个多余的 div。