### PR TITLE
feat: support root style

### DIFF
--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -41,6 +41,7 @@ const Dialog: React.FC<IDialogPropTypes> = (props) => {
     maskStyle,
     maskProps,
     rootClassName,
+    rootStyle,
     classNames: modalClassNames,
     styles: modalStyles,
   } = props;
@@ -175,6 +176,7 @@ const Dialog: React.FC<IDialogPropTypes> = (props) => {
   return (
     <div
       className={classNames(`${prefixCls}-root`, rootClassName)}
+      style={rootStyle}
       {...pickAttrs(props, { data: true })}
     >
       <Mask

--- a/src/IDialogPropTypes.tsx
+++ b/src/IDialogPropTypes.tsx
@@ -11,6 +11,7 @@ export type IDialogPropTypes = {
   className?: string;
   keyboard?: boolean;
   style?: CSSProperties;
+  rootStyle?: CSSProperties;
   mask?: boolean;
   children?: React.ReactNode;
   afterClose?: () => any;

--- a/tests/__snapshots__/index.spec.tsx.snap
+++ b/tests/__snapshots__/index.spec.tsx.snap
@@ -49,54 +49,6 @@ exports[`dialog add rootClassName and rootStyle should render correct 1`] = `
 </div>
 `;
 
-exports[`dialog add rootClassName should render correct 1`] = `
-<div
-  class="rc-dialog-root customize-root-class"
->
-  <div
-    class="rc-dialog-mask"
-  />
-  <div
-    class="rc-dialog-wrap"
-    style="font-size: 10px;"
-    tabindex="-1"
-  >
-    <div
-      aria-modal="true"
-      class="rc-dialog"
-      role="dialog"
-      style="width: 600px; height: 903px;"
-    >
-      <div
-        style="outline: none;"
-        tabindex="0"
-      >
-        <div
-          class="rc-dialog-section"
-        >
-          <button
-            aria-label="Close"
-            class="rc-dialog-close"
-            type="button"
-          >
-            <span
-              class="rc-dialog-close-x"
-            />
-          </button>
-          <div
-            class="rc-dialog-body"
-          />
-        </div>
-      </div>
-      <div
-        style="width: 0px; height: 0px; overflow: hidden; outline: none;"
-        tabindex="0"
-      />
-    </div>
-  </div>
-</div>
-`;
-
 exports[`dialog should render correct 1`] = `
 <div
   class="rc-dialog-root"

--- a/tests/__snapshots__/index.spec.tsx.snap
+++ b/tests/__snapshots__/index.spec.tsx.snap
@@ -1,5 +1,54 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dialog add rootClassName and rootStyle should render correct 1`] = `
+<div
+  class="rc-dialog-root customize-root-class"
+  style="font-size: 20px;"
+>
+  <div
+    class="rc-dialog-mask"
+  />
+  <div
+    class="rc-dialog-wrap"
+    style="font-size: 10px;"
+    tabindex="-1"
+  >
+    <div
+      aria-modal="true"
+      class="rc-dialog"
+      role="dialog"
+      style="width: 600px; height: 903px;"
+    >
+      <div
+        style="outline: none;"
+        tabindex="0"
+      >
+        <div
+          class="rc-dialog-section"
+        >
+          <button
+            aria-label="Close"
+            class="rc-dialog-close"
+            type="button"
+          >
+            <span
+              class="rc-dialog-close-x"
+            />
+          </button>
+          <div
+            class="rc-dialog-body"
+          />
+        </div>
+      </div>
+      <div
+        style="width: 0px; height: 0px; overflow: hidden; outline: none;"
+        tabindex="0"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`dialog add rootClassName should render correct 1`] = `
 <div
   class="rc-dialog-root customize-root-class"

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -36,12 +36,13 @@ describe('dialog', () => {
     expect(wrapper.render()).toMatchSnapshot();
   });
 
-  it('add rootClassName should render correct', () => {
+  it('add rootClassName and rootStyle should render correct', () => {
     const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const wrapper = mount(
       <Dialog
         visible
         rootClassName="customize-root-class"
+        rootStyle={{ fontSize: 20 }}
         style={{ width: 600 }}
         height={903}
         wrapStyle={{ fontSize: 10 }}
@@ -56,6 +57,7 @@ describe('dialog', () => {
     );
     expect(wrapper.find('.customize-root-class').length).toBeTruthy();
     expect(wrapper.find('.rc-dialog-wrap').props().style.fontSize).toBe(10);
+    expect(wrapper.find('.rc-dialog-root').props().style.fontSize).toBe(20);
     expect(wrapper.find('.rc-dialog').props().style.height).toEqual(903);
     expect(wrapper.find('.rc-dialog').props().style.width).toEqual(600);
   });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 为对话框组件添加了 `rootStyle` 属性，允许用户自定义根元素的内联样式。

- **改进**
	- 增强了对话框组件的样式定制灵活性。
	- 更新了测试用例，以验证新属性的正确渲染。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->