### PR TITLE
fix: Free lock if motion not start

### DIFF
--- a/docs/examples/multiple-Portal.tsx
+++ b/docs/examples/multiple-Portal.tsx
@@ -46,8 +46,19 @@ const Demo: React.FC = () => {
       <button type="button" onClick={onToggleDialog}>
         open dialog
       </button>
+      <button
+        type="button"
+        onClick={() => {
+          setShowDialog(true);
+          setTimeout(() => {
+            setShowDialog(false);
+          }, 0);
+        }}
+      >
+        quick
+      </button>
       {dialog}
-      {/* {drawer} */}
+      {drawer}
     </div>
   );
 };

--- a/docs/examples/multiple-Portal.tsx
+++ b/docs/examples/multiple-Portal.tsx
@@ -24,6 +24,7 @@ const Demo: React.FC = () => {
       onClose={onToggleDialog}
       forceRender
       title="basic modal"
+      mask={false}
     >
       <p>
         <button type="button" onClick={onToggleDrawer}>
@@ -46,7 +47,7 @@ const Demo: React.FC = () => {
         open dialog
       </button>
       {dialog}
-      {drawer}
+      {/* {drawer} */}
     </div>
   );
 };

--- a/docs/examples/multiple-Portal.tsx
+++ b/docs/examples/multiple-Portal.tsx
@@ -24,7 +24,6 @@ const Demo: React.FC = () => {
       onClose={onToggleDialog}
       forceRender
       title="basic modal"
-      mask={false}
     >
       <p>
         <button type="button" onClick={onToggleDrawer}>

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@rc-component/portal": "^1.0.0-8",
     "@rc-component/util": "^1.0.1",
     "classnames": "^2.2.6",
-    "@rc-component/motion": "^1.1.0"
+    "@rc-component/motion": "^1.1.3"
   },
   "devDependencies": {
     "@rc-component/father-plugin": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint:tsc": "tsc -p tsconfig.json --noEmit",
     "now-build": "npm run docs:build",
     "prepare": "husky install",
-    "prepublishOnly": "npm run compile && np --yolo --no-publish",
+    "prepublishOnly": "npm run compile && rc-np",
     "prettier": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "start": "dumi dev",
     "test": "rc-test"
@@ -49,14 +49,14 @@
     ]
   },
   "dependencies": {
-    "@babel/runtime": "^7.10.1",
     "@rc-component/portal": "^1.0.0-8",
     "@rc-component/util": "^1.0.1",
     "classnames": "^2.2.6",
-    "rc-motion": "^2.3.0"
+    "@rc-component/motion": "^1.1.0"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.1",
+    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^6.1.6",
     "@testing-library/react": "^13.0.0",
     "@types/jest": "^29.4.0",
@@ -77,7 +77,6 @@
     "husky": "^8.0.3",
     "less": "^4.1.3",
     "lint-staged": "^15.2.0",
-    "np": "^10.0.5",
     "prettier": "^3.2.1",
     "rc-drawer": "^7.0.0",
     "rc-select": "^14.11.0",

--- a/src/Dialog/Content/Panel.tsx
+++ b/src/Dialog/Content/Panel.tsx
@@ -17,12 +17,12 @@ export interface PanelProps extends Omit<IDialogPropTypes, 'getOpenCount'> {
   holderRef?: React.Ref<HTMLDivElement>;
 }
 
-export type ContentRef = {
+export type PanelRef = {
   focus: () => void;
   changeActive: (next: boolean) => void;
 };
 
-const Panel = React.forwardRef<ContentRef, PanelProps>((props, ref) => {
+const Panel = React.forwardRef<PanelRef, PanelProps>((props, ref) => {
   const {
     prefixCls,
     className,

--- a/src/Dialog/Content/index.tsx
+++ b/src/Dialog/Content/index.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { useRef } from 'react';
 import classNames from 'classnames';
-import CSSMotion from 'rc-motion';
+import CSSMotion from '@rc-component/motion';
 import { offset } from '../../util';
 import type { PanelProps, ContentRef } from './Panel';
 import Panel from './Panel';
+
+console.log(CSSMotion);
 
 export type ContentProps = {
   motionName: string;
@@ -27,7 +29,10 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
     mousePosition,
   } = props;
 
-  const dialogRef = useRef<HTMLDivElement>();
+  const dialogRef = useRef<{
+    nativeElement: HTMLDivElement;
+    inMotion: () => boolean;
+  }>();
 
   // ============================= Style ==============================
   const [transformOrigin, setTransformOrigin] = React.useState<string>();
@@ -38,7 +43,8 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
   }
 
   function onPrepare() {
-    const elementOffset = offset(dialogRef.current);
+    console.log('onPrepare', dialogRef.current);
+    const elementOffset = offset(dialogRef.current?.nativeElement);
 
     setTransformOrigin(
       mousePosition && (mousePosition.x || mousePosition.y)
@@ -46,6 +52,12 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
         : '',
     );
   }
+
+  const bbb = React.useCallback((aaa) => {
+    console.log('???', aaa);
+    dialogRef.current = aaa;
+  }, []);
+  console.log('render....');
 
   // ============================= Render =============================
   return (
@@ -57,7 +69,7 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
       forceRender={forceRender}
       motionName={motionName}
       removeOnLeave={destroyOnClose}
-      ref={dialogRef}
+      ref={bbb}
     >
       {({ className: motionClassName, style: motionStyle }, motionRef) => (
         <Panel

--- a/src/Dialog/Content/index.tsx
+++ b/src/Dialog/Content/index.tsx
@@ -3,10 +3,13 @@ import { useRef } from 'react';
 import classNames from 'classnames';
 import CSSMotion from '@rc-component/motion';
 import { offset } from '../../util';
-import type { PanelProps, ContentRef } from './Panel';
+import type { PanelProps, PanelRef } from './Panel';
 import Panel from './Panel';
 
-console.log(CSSMotion);
+export type ContentRef = PanelRef & {
+  inMotion: () => boolean;
+  enableMotion: () => boolean;
+};
 
 export type ContentProps = {
   motionName: string;
@@ -34,6 +37,15 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
     inMotion: () => boolean;
   }>();
 
+  const panelRef = useRef<PanelRef>();
+
+  // ============================== Refs ==============================
+  React.useImperativeHandle(ref, () => ({
+    ...panelRef.current,
+    inMotion: dialogRef.current.inMotion,
+    enableMotion: dialogRef.current.enableMotion,
+  }));
+
   // ============================= Style ==============================
   const [transformOrigin, setTransformOrigin] = React.useState<string>();
   const contentStyle: React.CSSProperties = {};
@@ -43,8 +55,7 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
   }
 
   function onPrepare() {
-    console.log('onPrepare', dialogRef.current);
-    const elementOffset = offset(dialogRef.current?.nativeElement);
+    const elementOffset = offset(dialogRef.current.nativeElement);
 
     setTransformOrigin(
       mousePosition && (mousePosition.x || mousePosition.y)
@@ -52,12 +63,6 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
         : '',
     );
   }
-
-  const bbb = React.useCallback((aaa) => {
-    console.log('???', aaa);
-    dialogRef.current = aaa;
-  }, []);
-  console.log('render....');
 
   // ============================= Render =============================
   return (
@@ -69,12 +74,12 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
       forceRender={forceRender}
       motionName={motionName}
       removeOnLeave={destroyOnClose}
-      ref={bbb}
+      ref={dialogRef}
     >
       {({ className: motionClassName, style: motionStyle }, motionRef) => (
         <Panel
           {...props}
-          ref={ref}
+          ref={panelRef}
           title={title}
           ariaId={ariaId}
           prefixCls={prefixCls}

--- a/src/Dialog/Content/index.tsx
+++ b/src/Dialog/Content/index.tsx
@@ -5,11 +5,11 @@ import CSSMotion from '@rc-component/motion';
 import { offset } from '../../util';
 import type { PanelProps, PanelRef } from './Panel';
 import Panel from './Panel';
+import type { CSSMotionRef } from '@rc-component/motion/es/CSSMotion';
 
-export type ContentRef = PanelRef & {
-  inMotion: () => boolean;
-  enableMotion: () => boolean;
-};
+export type CSSMotionStateRef = Pick<CSSMotionRef, 'inMotion' | 'enableMotion'>;
+
+export type ContentRef = PanelRef & CSSMotionStateRef;
 
 export type ContentProps = {
   motionName: string;
@@ -32,10 +32,11 @@ const Content = React.forwardRef<ContentRef, ContentProps>((props, ref) => {
     mousePosition,
   } = props;
 
-  const dialogRef = useRef<{
-    nativeElement: HTMLDivElement;
-    inMotion: () => boolean;
-  }>();
+  const dialogRef = useRef<
+    {
+      nativeElement: HTMLElement;
+    } & CSSMotionStateRef
+  >();
 
   const panelRef = useRef<PanelRef>();
 

--- a/src/Dialog/Mask.tsx
+++ b/src/Dialog/Mask.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import CSSMotion from 'rc-motion';
+import CSSMotion from '@rc-component/motion';
 
 export type MaskProps = {
   prefixCls: string;

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -104,7 +104,6 @@ const Dialog: React.FC<IDialogPropTypes> = (props) => {
     if (newVisible) {
       focusDialogContent();
     } else {
-      console.log('hide???');
       doClose();
     }
     afterOpenChange?.(newVisible);

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -519,13 +519,10 @@ describe('dialog', () => {
         jest.runAllTimers();
       });
 
-      console.log('~~~~~~false~~~~~~');
       rerender(<Dialog afterClose={afterClose} visible={false} />);
-      console.log('~~~~~~111~~~~~~');
       act(() => {
         jest.runAllTimers();
       });
-      console.log('~~~~~~222~~~~~~');
 
       expect(afterClose).toHaveBeenCalledTimes(1);
     });

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -515,10 +515,17 @@ describe('dialog', () => {
       const afterClose = jest.fn();
 
       const { rerender } = render(<Dialog afterClose={afterClose} visible />);
-      jest.runAllTimers();
+      act(() => {
+        jest.runAllTimers();
+      });
 
+      console.log('~~~~~~false~~~~~~');
       rerender(<Dialog afterClose={afterClose} visible={false} />);
-      jest.runAllTimers();
+      console.log('~~~~~~111~~~~~~');
+      act(() => {
+        jest.runAllTimers();
+      });
+      console.log('~~~~~~222~~~~~~');
 
       expect(afterClose).toHaveBeenCalledTimes(1);
     });

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -1,14 +1,14 @@
 /* eslint-disable react/no-render-return-value, max-classes-per-file, func-names, no-console */
 import { fireEvent, render, act } from '@testing-library/react';
-import { Provider } from 'rc-motion';
+import { Provider } from '@rc-component/motion';
 import KeyCode from '@rc-component/util/lib/KeyCode';
 import React, { cloneElement, useEffect } from 'react';
 import type { DialogProps } from '../src';
 import Dialog from '../src';
 
-jest.mock('rc-motion', () => {
+jest.mock('@rc-component/motion', () => {
   const OriReact = jest.requireActual('react');
-  const origin = jest.requireActual('rc-motion');
+  const origin = jest.requireActual('@rc-component/motion');
   const OriCSSMotion = origin.default;
 
   const ProxyCSSMotion = OriReact.forwardRef((props: any, ref: any) => {

--- a/tests/ref.spec.tsx
+++ b/tests/ref.spec.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-render-return-value, max-classes-per-file, func-names, no-console */
 import { render } from '@testing-library/react';
-import { Provider } from 'rc-motion';
+import { Provider } from '@rc-component/motion';
 import React from 'react';
 import Dialog from '../src';
 


### PR DESCRIPTION
ref https://github.com/ant-design/ant-design/issues/52625

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新增功能**
  - 在演示组件中新增了一个“快速”按钮，可即时触发短暂显示对话框的交互效果。

- **重构**
  - 优化了对话框的关闭逻辑和引用处理，进一步整合交互流程，提升用户体验。

- **构建和依赖维护**
  - 更新了发布流程及构建脚本，同时调整了部分依赖项，确保项目持续稳定运作。

- **测试**
  - 改进了异步操作和组件引用的测试用例，增强了测试的准确性与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->