### PR TITLE
feat: Merge 'afterClose' to 'closable'

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,12 @@ ReactDOM.render(
 | maskTransitionName | String |  | mask animation css class name |  |
 | title | String\|React.Element |  | Title of the dialog |  |
 | footer | React.Element |  | footer of the dialog |  |
-| closable | Boolean \| ({ closeIcon?: React.ReactNode; disabled?: boolean } & React.AriaAttributes | true | whether show close button |  |
+| closable | Boolean \| ({ closeIcon?: React.ReactNode; disabled?: boolean, afterClose:function } & React.AriaAttributes) | true | whether show close button |  |
 | mask | Boolean | true | whether show mask |  |
 | maskClosable | Boolean | true | whether click mask to close |  |
 | keyboard | Boolean | true | whether support press esc to close |  |
 | mousePosition | {x:number,y:number} |  | set pageX and pageY of current mouse(it will cause transform origin to be set). |  |
 | onClose | function() |  | called when click close button or mask |  |
-| afterClose | function() |  | called when close animation end |  |
 | getContainer | function(): HTMLElement |  | to determine where Dialog will be mounted |  |
 | destroyOnHidden | Boolean | false | to unmount child compenents on onClose |  |
 | closeIcon | ReactNode |  | specific the close icon. |  |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ ReactDOM.render(
 | keyboard | Boolean | true | whether support press esc to close |  |
 | mousePosition | {x:number,y:number} |  | set pageX and pageY of current mouse(it will cause transform origin to be set). |  |
 | onClose | function() |  | called when click close button or mask |  |
+| ~~afterClose~~ | function() |  | called when close animation end |  |
 | getContainer | function(): HTMLElement |  | to determine where Dialog will be mounted |  |
 | destroyOnHidden | Boolean | false | to unmount child compenents on onClose |  |
 | closeIcon | ReactNode |  | specific the close icon. |  |

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ ReactDOM.render(
 | keyboard | Boolean | true | whether support press esc to close |  |
 | mousePosition | {x:number,y:number} |  | set pageX and pageY of current mouse(it will cause transform origin to be set). |  |
 | onClose | function() |  | called when click close button or mask |  |
-| ~~afterClose~~ | function() |  | called when close animation end |  |
+| afterClose | function() |  | called when close animation end |  |
 | getContainer | function(): HTMLElement |  | to determine where Dialog will be mounted |  |
 | destroyOnHidden | Boolean | false | to unmount child compenents on onClose |  |
 | closeIcon | ReactNode |  | specific the close icon. |  |

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -95,7 +95,8 @@ const Dialog: React.FC<IDialogPropTypes> = (props) => {
 
     // Trigger afterClose only when change visible from true to false
     if (animatedVisible) {
-      ((closable as ClosableType)?.afterClose ?? afterClose)?.();
+      const { afterClose: closableAfterClose } = typeof closable === 'object' ? closable : {};
+      (closableAfterClose ?? afterClose)?.();
     }
   }
 

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -5,7 +5,7 @@ import KeyCode from '@rc-component/util/lib/KeyCode';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
-import type { IDialogPropTypes } from '../IDialogPropTypes';
+import type { ClosableType, IDialogPropTypes } from '../IDialogPropTypes';
 import { getMotionName } from '../util';
 import Content, { type ContentRef } from './Content';
 import Mask from './Mask';
@@ -95,7 +95,7 @@ const Dialog: React.FC<IDialogPropTypes> = (props) => {
 
     // Trigger afterClose only when change visible from true to false
     if (animatedVisible) {
-      afterClose?.();
+      ((closable as ClosableType)?.afterClose ?? afterClose)?.();
     }
   }
 

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -167,7 +167,7 @@ const Dialog: React.FC<IDialogPropTypes> = (props) => {
     ) {
       doClose();
     }
-  }, [visible, animatedVisible, doClose]);
+  }, [visible]);
 
   // Remove direct should also check the scroll bar update
   useEffect(

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -5,7 +5,7 @@ import KeyCode from '@rc-component/util/lib/KeyCode';
 import pickAttrs from '@rc-component/util/lib/pickAttrs';
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
-import type { ClosableType, IDialogPropTypes } from '../IDialogPropTypes';
+import type { IDialogPropTypes } from '../IDialogPropTypes';
 import { getMotionName } from '../util';
 import Content, { type ContentRef } from './Content';
 import Mask from './Mask';

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -95,9 +95,7 @@ const Dialog: React.FC<IDialogPropTypes> = (props) => {
 
     // Trigger afterClose only when change visible from true to false
     if (animatedVisible) {
-      const { afterClose: closableAfterClose = undefined } =
-        typeof closable === 'object' ? closable : {};
-      (closableAfterClose ?? afterClose)?.();
+      afterClose?.();
     }
   }
 

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -167,7 +167,7 @@ const Dialog: React.FC<IDialogPropTypes> = (props) => {
     ) {
       doClose();
     }
-  }, [visible]);
+  }, [visible, animatedVisible, doClose]);
 
   // Remove direct should also check the scroll bar update
   useEffect(

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -95,7 +95,8 @@ const Dialog: React.FC<IDialogPropTypes> = (props) => {
 
     // Trigger afterClose only when change visible from true to false
     if (animatedVisible) {
-      const { afterClose: closableAfterClose } = typeof closable === 'object' ? closable : {};
+      const { afterClose: closableAfterClose = undefined } =
+        typeof closable === 'object' ? closable : {};
       (closableAfterClose ?? afterClose)?.();
     }
   }

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -52,7 +52,8 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
           afterClose={() => {
             const { afterClose: closableAfterClose = undefined } =
               typeof closable === 'object' ? closable : {};
-            (closableAfterClose ?? afterClose)?.();
+            closableAfterClose?.();
+            afterClose?.();
             setAnimatedVisible(false);
           }}
         />

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -51,7 +51,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
           destroyOnHidden={destroyOnHidden}
           afterClose={() => {
             const { afterClose: closableAfterClose } =
-              typeof closable === 'object' && closable ? closable : {};
+              closable && typeof closable === 'object' ? closable : {};
             closableAfterClose?.();
             afterClose?.();
             setAnimatedVisible(false);

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -50,8 +50,8 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
           {...props}
           destroyOnHidden={destroyOnHidden}
           afterClose={() => {
-            const { afterClose: closableAfterClose = undefined } =
-              typeof closable === 'object' && closable !== null ? closable : {};
+            const { afterClose: closableAfterClose } =
+              typeof closable === 'object' && closable ? closable : {};
             closableAfterClose?.();
             afterClose?.();
             setAnimatedVisible(false);

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -50,7 +50,8 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
           {...props}
           destroyOnHidden={destroyOnHidden}
           afterClose={() => {
-            const { afterClose: closableAfterClose } = typeof closable === 'object' ? closable : {};
+            const { afterClose: closableAfterClose = undefined } =
+              typeof closable === 'object' ? closable : {};
             (closableAfterClose ?? afterClose)?.();
             setAnimatedVisible(false);
           }}

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -51,7 +51,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
           destroyOnHidden={destroyOnHidden}
           afterClose={() => {
             const { afterClose: closableAfterClose = undefined } =
-              typeof closable === 'object' ? closable : {};
+              typeof closable === 'object' && closable !== null ? closable : {};
             closableAfterClose?.();
             afterClose?.();
             setAnimatedVisible(false);

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -2,7 +2,7 @@ import Portal from '@rc-component/portal';
 import * as React from 'react';
 import { RefContext } from './context';
 import Dialog from './Dialog';
-import type { ClosableType, IDialogPropTypes } from './IDialogPropTypes';
+import type { IDialogPropTypes } from './IDialogPropTypes';
 
 // fix issue #10656
 /*

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -2,7 +2,7 @@ import Portal from '@rc-component/portal';
 import * as React from 'react';
 import { RefContext } from './context';
 import Dialog from './Dialog';
-import type { IDialogPropTypes } from './IDialogPropTypes';
+import type { ClosableType, IDialogPropTypes } from './IDialogPropTypes';
 
 // fix issue #10656
 /*
@@ -20,6 +20,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
     forceRender,
     destroyOnHidden = false,
     afterClose,
+    closable,
     panelRef,
   } = props;
   const [animatedVisible, setAnimatedVisible] = React.useState<boolean>(visible);
@@ -49,7 +50,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
           {...props}
           destroyOnHidden={destroyOnHidden}
           afterClose={() => {
-            afterClose?.();
+            ((closable as ClosableType)?.afterClose ?? afterClose)?.();
             setAnimatedVisible(false);
           }}
         />

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -50,7 +50,8 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
           {...props}
           destroyOnHidden={destroyOnHidden}
           afterClose={() => {
-            ((closable as ClosableType)?.afterClose ?? afterClose)?.();
+            const { afterClose: closableAfterClose } = typeof closable === 'object' ? closable : {};
+            (closableAfterClose ?? afterClose)?.();
             setAnimatedVisible(false);
           }}
         />

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -51,7 +51,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
           destroyOnHidden={destroyOnHidden}
           afterClose={() => {
             const { afterClose: closableAfterClose } =
-              closable && typeof closable === 'object' ? closable : {};
+              (typeof closable === 'object' ? closable : {}) || {};
             closableAfterClose?.();
             afterClose?.();
             setAnimatedVisible(false);

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -50,8 +50,8 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
           {...props}
           destroyOnHidden={destroyOnHidden}
           afterClose={() => {
-            const { afterClose: closableAfterClose } =
-              (typeof closable === 'object' ? closable : {}) || {};
+            const closableObj = closable && typeof closable === 'object' ? closable : {};
+            const { afterClose: closableAfterClose } = closableObj || {};
             closableAfterClose?.();
             afterClose?.();
             setAnimatedVisible(false);

--- a/src/IDialogPropTypes.tsx
+++ b/src/IDialogPropTypes.tsx
@@ -7,6 +7,12 @@ export type ModalClassNames = Partial<Record<SemanticName, string>>;
 
 export type ModalStyles = Partial<Record<SemanticName, CSSProperties>>;
 
+export type ClosableType = {
+  closeIcon?: React.ReactNode;
+  disabled?: boolean;
+  afterClose?: () => any;
+};
+
 export type IDialogPropTypes = {
   className?: string;
   keyboard?: boolean;
@@ -14,10 +20,11 @@ export type IDialogPropTypes = {
   rootStyle?: CSSProperties;
   mask?: boolean;
   children?: React.ReactNode;
+  /** @description please use `closable.afterClose` instead */
   afterClose?: () => any;
   afterOpenChange?: (open: boolean) => void;
   onClose?: (e: SyntheticEvent) => any;
-  closable?: boolean | ({ closeIcon?: React.ReactNode; disabled?: boolean } & React.AriaAttributes);
+  closable?: boolean | (ClosableType & React.AriaAttributes);
   maskClosable?: boolean;
   visible?: boolean;
   destroyOnHidden?: boolean;

--- a/src/IDialogPropTypes.tsx
+++ b/src/IDialogPropTypes.tsx
@@ -20,7 +20,6 @@ export type IDialogPropTypes = {
   rootStyle?: CSSProperties;
   mask?: boolean;
   children?: React.ReactNode;
-  /** @description please use `closable.afterClose` instead */
   afterClose?: () => any;
   afterOpenChange?: (open: boolean) => void;
   onClose?: (e: SyntheticEvent) => any;

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -552,6 +552,40 @@ describe('dialog', () => {
 
       expect(afterClose).toHaveBeenCalledTimes(0);
     });
+
+    it('should trigger closable.afterClose when using new API', () => {
+      const afterClose = jest.fn();
+
+      const { rerender } = render(<Dialog closable={{ afterClose }} visible />);
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      rerender(<Dialog closable={{ afterClose }} visible={false} />);
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(afterClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should prioritize closable.afterClose when both exist', () => {
+      const afterClose = jest.fn();
+      const legacyAfterClose = jest.fn();
+
+      const { rerender } = render(
+        <Dialog closable={{ afterClose }} afterClose={legacyAfterClose} visible />,
+      );
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      rerender(<Dialog closable={{ afterClose }} afterClose={legacyAfterClose} visible={false} />);
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(afterClose).toHaveBeenCalledTimes(1);
+      expect(legacyAfterClose).toHaveBeenCalledTimes(0);
+    });
   });
 
   describe('afterOpenChange', () => {

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -553,21 +553,6 @@ describe('dialog', () => {
       expect(afterClose).toHaveBeenCalledTimes(0);
     });
 
-    it('should trigger closable.afterClose when using new API', () => {
-      const afterClose = jest.fn();
-
-      const { rerender } = render(<Dialog closable={{ afterClose }} visible />);
-      act(() => {
-        jest.runAllTimers();
-      });
-
-      rerender(<Dialog closable={{ afterClose }} visible={false} />);
-      act(() => {
-        jest.runAllTimers();
-      });
-      expect(afterClose).toHaveBeenCalledTimes(1);
-    });
-
     it('should prioritize closable.afterClose when both exist', () => {
       const afterClose = jest.fn();
       const legacyAfterClose = jest.fn();
@@ -584,7 +569,7 @@ describe('dialog', () => {
         jest.runAllTimers();
       });
       expect(afterClose).toHaveBeenCalledTimes(1);
-      expect(legacyAfterClose).toHaveBeenCalledTimes(0);
+      expect(legacyAfterClose).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
将afterClose属性合并到closable中，并添加测试与修改文档
afterClose -> closable.afterClose
关联issue https://github.com/ant-design/ant-design/issues/54394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新了 `closable` 属性的说明，支持在对象类型中新增可选的 `afterClose` 回调，并将独立的 `afterClose` 属性标记为已废弃。

* **新特性**
  * 支持通过 `closable` 属性对象传递 `afterClose` 回调函数，实现更灵活的关闭后处理。
  * 优化了对关闭动画和状态更新的处理逻辑，提升关闭流程的稳定性。

* **测试**
  * 增加了同时传递新旧 `afterClose` 回调时的行为测试，确保兼容性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->