### PR TITLE
fix: ignore dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   "files": [
     "lib",
     "es",
-    "assets/*.css",
-    "dist"
+    "assets/*.css"
   ],
   "scripts": {
     "compile": "father build && lessc assets/index.less assets/index.css && lessc assets/bootstrap.less assets/bootstrap.css",


### PR DESCRIPTION
> fix https://github.com/utooland/utoo/actions/runs/21403066957/job/61619257886

> Installing dependencies for ant-design...
 WARN Extract failed: @rc-component/dialog@1.8.1: Failed to create: C:\Users\runneradmin\.cache/nm\@rc-component/dialog\1.8.1\package/dist/~demos/:id/index.html

windows 下 ~demos/:id 路径非法，目前  package.json 配置为 
```
  "main": "./lib/index",
  "module": "./es/index",
```
dist 目录仅用于文档部署，不需要发布至 npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 更新内容

* **杂项更新**
  * 优化包发布配置，调整已发布文件集合。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->