### PR TITLE
fix(focus): add ignoreElement support and update deps

### DIFF
--- a/docs/demo/with-portal.md
+++ b/docs/demo/with-portal.md
@@ -1,0 +1,8 @@
+---
+title: with-portal
+nav:
+  title: Demo
+  path: /demo
+---
+
+<code src="../examples/with-portal.tsx"></code>

--- a/docs/examples/with-portal.tsx
+++ b/docs/examples/with-portal.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Dialog from '@rc-component/dialog';
+
+const DivPortal: React.FC = () => {
+  return ReactDOM.createPortal(
+    <div
+      id="test-portal"
+      style={{
+        position: 'fixed',
+        right: 20,
+        bottom: 20,
+        background: 'white',
+        padding: 20,
+        border: '1px solid #ccc',
+        zIndex: 1000000,
+      }}
+    >
+      <input type="text" />
+    </div>,
+    document.body
+  );
+};
+
+const MyControl: React.FC = () => {
+  const [visible, setVisible] = React.useState(false);
+
+  const onClick = () => {
+    setVisible(true);
+  };
+
+  const onClose = () => {
+    setVisible(false);
+  };
+
+  return (
+    <div style={{ margin: 20 }}>
+      <p>
+        <button type="button" onClick={onClick}>
+          show dialog
+        </button>
+      </p>
+      <Dialog visible={visible} onClose={onClose}>
+        hello world
+        <input type="text" />
+        <input type="text" />
+        <DivPortal />
+      </Dialog>
+    </div>
+  );
+};
+
+export default MyControl;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@rc-component/motion": "^1.1.3",
     "@rc-component/portal": "^2.1.0",
-    "@rc-component/util": "^1.7.0",
+    "@rc-component/util": "^1.9.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/Dialog/Content/Panel.tsx
+++ b/src/Dialog/Content/Panel.tsx
@@ -54,7 +54,10 @@ const Panel = React.forwardRef<PanelRef, PanelProps>((props, ref) => {
   const internalRef = useRef<HTMLDivElement>(null);
   const mergedRef = useComposeRef(holderRef, panelRef, internalRef);
 
-  useLockFocus(visible && isFixedPos && focusTrap !== false, () => internalRef.current);
+  const [ignoreElement] = useLockFocus(
+    visible && isFixedPos && focusTrap !== false,
+    () => internalRef.current,
+  );
 
   React.useImperativeHandle(ref, () => ({
     focus: () => {
@@ -152,6 +155,9 @@ const Panel = React.forwardRef<PanelRef, PanelProps>((props, ref) => {
       onMouseDown={onMouseDown}
       onMouseUp={onMouseUp}
       tabIndex={-1}
+      onFocus={(e) => {
+        ignoreElement(e.target);
+      }}
     >
       <MemoChildren shouldUpdate={visible || forceRender}>
         {modalRender ? modalRender(content) : content}

--- a/tests/focus.spec.tsx
+++ b/tests/focus.spec.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable react/no-render-return-value, max-classes-per-file, func-names, no-console */
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { act, render } from '@testing-library/react';
 import Dialog from '../src';
 
@@ -9,7 +10,12 @@ jest.mock('@rc-component/util/lib/Dom/focus', () => {
 
   const useLockFocus = (visible: boolean, ...rest: any[]) => {
     globalThis.__useLockFocusVisible = visible;
-    return actual.useLockFocus(visible, ...rest);
+    const hooks = actual.useLockFocus(visible, ...rest);
+    const proxyIgnoreElement = (ele) => {
+      globalThis.__ignoredElement = ele;
+      hooks[0](ele);
+    };
+    return [proxyIgnoreElement, ...hooks.slice(1)] as ReturnType<typeof actual.useLockFocus>;
   };
 
   return {
@@ -81,5 +87,24 @@ describe('Dialog.Focus', () => {
     });
 
     expect(globalThis.__useLockFocusVisible).toBe(false);
+  });
+
+  it('should call ignoreElement when input in portal is focused', () => {
+    render(
+      <Dialog visible styles={{ wrapper: { position: 'fixed' } }}>
+        {ReactDOM.createPortal(<input id="portal-input" />, document.body)}
+      </Dialog>,
+    );
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    const input = document.getElementById('portal-input') as HTMLElement;
+    act(() => {
+      input.focus();
+    });
+
+    expect(globalThis.__ignoredElement).toBe(input);
   });
 });

--- a/tests/focus.spec.tsx
+++ b/tests/focus.spec.tsx
@@ -11,7 +11,7 @@ jest.mock('@rc-component/util/lib/Dom/focus', () => {
   const useLockFocus = (visible: boolean, ...rest: any[]) => {
     globalThis.__useLockFocusVisible = visible;
     const hooks = actual.useLockFocus(visible, ...rest);
-    const proxyIgnoreElement = (ele) => {
+    const proxyIgnoreElement = (ele: HTMLElement) => {
       globalThis.__ignoredElement = ele;
       hooks[0](ele);
     };


### PR DESCRIPTION
- Update @rc-component/util to 1.9.0
- Add ignoreElement to handle focus elements from Portal
- Remove console.log in Panel component
- Add test case for focus handling with Portal

fix https://github.com/ant-design/ant-design/issues/56782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加了门户（Portal）渲染的文档与可运行示例，演示在对话框中使用门户的用法。

* **错误修复**
  * 改进了对话框内固定定位内容的焦点管理，提升焦点处理准确性。

* **测试**
  * 新增覆盖门户内聚焦行为的自动化测试，验证焦点忽略逻辑。

* **Chores**
  * 更新了项目依赖的版本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->