### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,12 +51,12 @@
   "dependencies": {
     "@rc-component/motion": "^1.1.3",
     "@rc-component/portal": "^2.1.0",
-    "@rc-component/util": "^1.9.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
     "@rc-component/drawer": "^1.0.0",
-    "@rc-component/father-plugin": "^2.0.2",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@rc-component/select": "^1.0.0",
     "@testing-library/jest-dom": "^6.1.6",

--- a/src/Dialog/Content/Panel.tsx
+++ b/src/Dialog/Content/Panel.tsx
@@ -1,11 +1,9 @@
 import { clsx } from 'clsx';
-import { useComposeRef } from '@rc-component/util/lib/ref';
-import { useLockFocus } from '@rc-component/util/lib/Dom/focus';
+import { pickAttrs, useComposeRef, useLockFocus } from '@rc-component/util';
 import React, { useMemo, useRef } from 'react';
 import { RefContext } from '../../context';
 import type { IDialogPropTypes } from '../../IDialogPropTypes';
 import MemoChildren from './MemoChildren';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
 
 export interface PanelProps extends Omit<IDialogPropTypes, 'getOpenCount'> {
   prefixCls: string;

--- a/src/Dialog/Content/index.tsx
+++ b/src/Dialog/Content/index.tsx
@@ -1,11 +1,10 @@
 import * as React from 'react';
 import { useRef } from 'react';
 import { clsx } from 'clsx';
-import CSSMotion from '@rc-component/motion';
+import CSSMotion, { type CSSMotionRef } from '@rc-component/motion';
 import { offset } from '../../util';
 import type { PanelProps, PanelRef } from './Panel';
 import Panel from './Panel';
-import type { CSSMotionRef } from '@rc-component/motion/es/CSSMotion';
 
 export type CSSMotionStateRef = Pick<CSSMotionRef, 'inMotion' | 'enableMotion'>;
 

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -1,14 +1,11 @@
 import { clsx } from 'clsx';
-import contains from '@rc-component/util/lib/Dom/contains';
-import useId from '@rc-component/util/lib/hooks/useId';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { contains, pickAttrs, useId, warning } from '@rc-component/util';
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
 import type { IDialogPropTypes } from '../IDialogPropTypes';
 import { getMotionName } from '../util';
 import Content, { type ContentRef } from './Content';
 import Mask from './Mask';
-import { warning } from '@rc-component/util/lib/warning';
 
 const Dialog: React.FC<IDialogPropTypes> = (props) => {
   const {

--- a/src/IDialogPropTypes.ts
+++ b/src/IDialogPropTypes.ts
@@ -1,4 +1,4 @@
-import type { GetContainer } from '@rc-component/util/lib/PortalWrapper';
+import type { GetContainer } from '@rc-component/util';
 import type { CSSProperties, ReactNode, SyntheticEvent } from 'react';
 
 export type SemanticName = 'header' | 'body' | 'footer' | 'container' | 'title' | 'wrapper' | 'mask' | 'close';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
 import DialogWrap from './DialogWrap';
 import Panel from './Dialog/Content/Panel';
-import type { PanelProps } from './Dialog/Content/Panel';
 import type { IDialogPropTypes as DialogProps } from './IDialogPropTypes';
 
-export type { DialogProps, PanelProps };
+export type { DialogProps };
 export { Panel };
 
 export default DialogWrap;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import DialogWrap from './DialogWrap';
 import Panel from './Dialog/Content/Panel';
+import type { PanelProps } from './Dialog/Content/Panel';
 import type { IDialogPropTypes as DialogProps } from './IDialogPropTypes';
 
-export type { DialogProps };
+export type { DialogProps, PanelProps };
 export { Panel };
 
 export default DialogWrap;

--- a/tests/focus.spec.tsx
+++ b/tests/focus.spec.tsx
@@ -4,9 +4,9 @@ import ReactDOM from 'react-dom';
 import { act, render } from '@testing-library/react';
 import Dialog from '../src';
 
-// Mock: import { useLockFocus } from '@rc-component/util/lib/Dom/focus';
-jest.mock('@rc-component/util/lib/Dom/focus', () => {
-  const actual = jest.requireActual('@rc-component/util/lib/Dom/focus');
+// Mock: import { useLockFocus } from '@rc-component/util';
+jest.mock('@rc-component/util', () => {
+  const actual = jest.requireActual('@rc-component/util');
 
   const useLockFocus = (visible: boolean, ...rest: any[]) => {
     globalThis.__useLockFocusVisible = visible;


### PR DESCRIPTION
## 背景

antd 侧限制继续使用 rc 包的 `lib` / `es` 深路径导入，需要将 dialog 中对 rc 包内部路径的依赖迁移到包根入口。

## 调整内容

- 升级 `@rc-component/father-plugin`，使用插件统一拦截 rc 包 `lib` / `es` 深路径导入。
- 升级 `@rc-component/util`。
- 将源码中 `useComposeRef`、`useLockFocus`、`pickAttrs`、`contains`、`useId`、`warning` 等内部路径引用改为从 `@rc-component/util` 根入口导入。
- 将 `CSSMotionRef` 类型改为从 `@rc-component/motion` 根入口导入。
- 同步调整 focus 测试中的 `useLockFocus` mock 目标，保留原有测试语义。
- 补充导出 `PanelProps` 类型。

## 验证

- `npm run lint`
- `npm run lint:tsc`
- `npm test -- --runInBand`
- `npm run compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新特性**
  * 新增 `PanelProps` 类型公开导出，供开发者集成对话框面板时使用。

* **其他优化**
  * 升级核心依赖版本以改进稳定性和性能。
  * 优化内部导入结构以减少冗余。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/dialog/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->