### PR TITLE
feat: add scrollLock prop to control body scroll lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ ReactDOM.render(
 | closeIcon | ReactNode |  | specific the close icon. |  |
 | forceRender | Boolean | false | Create dialog dom node before dialog first show |  |
 | focusTriggerAfterClose | Boolean | true | focus trigger element when dialog closed |  |
+| scrollLock | Boolean | true | Control whether to lock body scroll when dialog opens |  |
 | modalRender | (node: ReactNode) => ReactNode |  | Custom modal content render | 8.3.0 |
 
 ## Development

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -23,6 +23,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
     closable,
     panelRef,
     keyboard = true,
+    scrollLock = true,
     onClose,
   } = props;
   const [animatedVisible, setAnimatedVisible] = React.useState<boolean>(visible);
@@ -55,7 +56,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
         onEsc={onEsc}
         autoDestroy={false}
         getContainer={getContainer}
-        autoLock={visible || animatedVisible}
+        autoLock={scrollLock && (visible || animatedVisible)}
       >
         <Dialog
           {...props}

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -26,6 +26,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
     scrollLock = true,
     onClose,
   } = props;
+  const { scrollLock: _, ...restProps } = props;
   const [animatedVisible, setAnimatedVisible] = React.useState<boolean>(visible);
 
   const refContext = React.useMemo(() => ({ panel: panelRef }), [panelRef]);
@@ -59,7 +60,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
         autoLock={scrollLock && (visible || animatedVisible)}
       >
         <Dialog
-          {...props}
+          {...restProps}
           destroyOnHidden={destroyOnHidden}
           afterClose={() => {
             const closableObj = closable && typeof closable === 'object' ? closable : {};

--- a/src/IDialogPropTypes.ts
+++ b/src/IDialogPropTypes.ts
@@ -59,6 +59,8 @@ export type IDialogPropTypes = {
   // https://github.com/react-component/dialog/issues/95
   focusTriggerAfterClose?: boolean;
   focusTrap?: boolean;
+  /** Control whether to lock body scroll when modal opens. Default is true. */
+  scrollLock?: boolean;
 
   // Refs
   panelRef?: React.Ref<HTMLDivElement>;

--- a/tests/scroll.spec.tsx
+++ b/tests/scroll.spec.tsx
@@ -78,4 +78,23 @@ describe('Dialog.Scroll', () => {
 
     unmount();
   });
+
+  it('should not lock body scroll when scrollLock is false', () => {
+    const { unmount, rerender } = render(<Dialog visible scrollLock={false} />);
+
+    // body should not have overflow:hidden when scrollLock is false
+    expect(document.body).not.toHaveStyle({
+      overflowY: 'hidden',
+    });
+
+    unmount();
+  });
+
+  it('should lock body scroll when scrollLock is true (default)', () => {
+    const { unmount, rerender } = render(<Dialog visible scrollLock={true} />);
+    expect(document.body).toHaveStyle({
+      overflowY: 'hidden',
+    });
+    unmount();
+  });
 });

--- a/tests/scroll.spec.tsx
+++ b/tests/scroll.spec.tsx
@@ -80,7 +80,7 @@ describe('Dialog.Scroll', () => {
   });
 
   it('should not lock body scroll when scrollLock is false', () => {
-    const { unmount, rerender } = render(<Dialog visible scrollLock={false} />);
+    const { unmount } = render(<Dialog visible scrollLock={false} />);
 
     // body should not have overflow:hidden when scrollLock is false
     expect(document.body).not.toHaveStyle({
@@ -91,7 +91,7 @@ describe('Dialog.Scroll', () => {
   });
 
   it('should lock body scroll when scrollLock is true (default)', () => {
-    const { unmount, rerender } = render(<Dialog visible scrollLock={true} />);
+    const { unmount } = render(<Dialog visible scrollLock={true} />);
     expect(document.body).toHaveStyle({
       overflowY: 'hidden',
     });


### PR DESCRIPTION
## Summary

  Add `scrollLock` prop to control whether to lock body scroll when dialog opens.

  ## Background

  Related issue: #32567

  Users want to be able to interact with background elements when modal is open. Currently, the modal locks body
  scroll by default.
  
  ## Solution

  Add `scrollLock` prop (default: true) to control body scroll lock behavior.

  ### API

  ```tsx
  <Modal scrollLock={false}>
    {/* User can interact with background */}
  </Modal>

  - scrollLock={true} (default): Lock body scroll (existing behavior)
  - scrollLock={false}: Do not lock body scroll
```

  Changelog

  │  Language  │                                  Changelog                                   │

  │ 🇺🇸 English │ Add scrollLock prop to control whether to lock body scroll when dialog opens │

  │ 🇨🇳 Chinese │ 新增 scrollLock 属性，用于控制对话框打开时是否锁定 body 滚动                 │


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 添加 `scrollLock` 配置项（默认启用），允许用户控制对话框打开时是否锁定页面滚动。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->