### PR TITLE
feat: adjust @rc-component/util imports to root path

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     ]
   },
   "dependencies": {
-    "@rc-component/motion": "^1.1.3",
+    "@rc-component/motion": "^1.3.3",
     "@rc-component/portal": "^2.1.0",
     "@rc-component/util": "^1.9.0",
     "clsx": "^2.1.1"

--- a/src/Dialog/Content/Panel.tsx
+++ b/src/Dialog/Content/Panel.tsx
@@ -1,11 +1,9 @@
 import { clsx } from 'clsx';
-import { useComposeRef } from '@rc-component/util/lib/ref';
-import { useLockFocus } from '@rc-component/util/lib/Dom/focus';
+import { useComposeRef, useLockFocus, pickAttrs } from '@rc-component/util';
 import React, { useMemo, useRef } from 'react';
 import { RefContext } from '../../context';
 import type { IDialogPropTypes } from '../../IDialogPropTypes';
 import MemoChildren from './MemoChildren';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
 
 export interface PanelProps extends Omit<IDialogPropTypes, 'getOpenCount'> {
   prefixCls: string;

--- a/src/Dialog/Content/index.tsx
+++ b/src/Dialog/Content/index.tsx
@@ -2,10 +2,10 @@ import * as React from 'react';
 import { useRef } from 'react';
 import { clsx } from 'clsx';
 import CSSMotion from '@rc-component/motion';
+import type { CSSMotionRef } from '@rc-component/motion';
 import { offset } from '../../util';
 import type { PanelProps, PanelRef } from './Panel';
 import Panel from './Panel';
-import type { CSSMotionRef } from '@rc-component/motion/es/CSSMotion';
 
 export type CSSMotionStateRef = Pick<CSSMotionRef, 'inMotion' | 'enableMotion'>;
 

--- a/src/Dialog/index.tsx
+++ b/src/Dialog/index.tsx
@@ -1,14 +1,11 @@
 import { clsx } from 'clsx';
-import contains from '@rc-component/util/lib/Dom/contains';
-import useId from '@rc-component/util/lib/hooks/useId';
-import pickAttrs from '@rc-component/util/lib/pickAttrs';
+import { contains, useId, pickAttrs, warning } from '@rc-component/util';
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
 import type { IDialogPropTypes } from '../IDialogPropTypes';
 import { getMotionName } from '../util';
 import Content, { type ContentRef } from './Content';
 import Mask from './Mask';
-import { warning } from '@rc-component/util/lib/warning';
 
 const Dialog: React.FC<IDialogPropTypes> = (props) => {
   const {

--- a/src/IDialogPropTypes.ts
+++ b/src/IDialogPropTypes.ts
@@ -1,4 +1,4 @@
-import type { GetContainer } from '@rc-component/util/lib/PortalWrapper';
+import type { GetContainer } from '@rc-component/util';
 import type { CSSProperties, ReactNode, SyntheticEvent } from 'react';
 
 export type SemanticName = 'header' | 'body' | 'footer' | 'container' | 'title' | 'wrapper' | 'mask' | 'close';

--- a/tests/focus.spec.tsx
+++ b/tests/focus.spec.tsx
@@ -4,9 +4,9 @@ import ReactDOM from 'react-dom';
 import { act, render } from '@testing-library/react';
 import Dialog from '../src';
 
-// Mock: import { useLockFocus } from '@rc-component/util/lib/Dom/focus';
-jest.mock('@rc-component/util/lib/Dom/focus', () => {
-  const actual = jest.requireActual('@rc-component/util/lib/Dom/focus');
+// Mock: import { useLockFocus } from '@rc-component/util';
+jest.mock('@rc-component/util', () => {
+  const actual = jest.requireActual('@rc-component/util');
 
   const useLockFocus = (visible: boolean, ...rest: any[]) => {
     globalThis.__useLockFocusVisible = visible;


### PR DESCRIPTION
## 背景

  项目中有多个文件使用非根路径方式引入 `@rc-component/util` 的模块，为了统一代码风格并遵循 eslint
  规则（`no-restricted-imports`），将所有引入调整为从包根路径导入。

  ## 主要改动

  - `src/Dialog/index.tsx`: 将 `contains`, `useId`, `pickAttrs`, `warning` 的引入从子路径调整为根路径引入
  - `src/Dialog/Content/Panel.tsx`: 将 `useComposeRef`, `useLockFocus`, `pickAttrs` 的引入从子路径调整为根路径引入
  - `src/IDialogPropTypes.ts`: 将 `GetContainer` 类型的引入从子路径调整为根路径引入
  - `tests/focus.spec.tsx`: 更新 jest mock 路径


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 统一并简化了内部工具的导入方式以改进代码组织（对外行为保持不变）。
* **Tests**
  * 调整了测试的模拟实现以匹配新的内部导入方式，测试逻辑和断言未修改。
* **Chores**
  * 更新了一个依赖包的版本以保持依赖项现代化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->