### PR TITLE
fix: #556 guard against undefined window in getScroll

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -9,6 +9,7 @@ export function getMotionName(prefixCls: string, transitionName?: string, animat
 
 // =============================== Offset ===============================
 function getScroll(w: Window, top?: boolean): number {
+  if (!w) return 0;
   let ret = w[`page${top ? 'Y' : 'X'}Offset`];
   const method = `scroll${top ? 'Top' : 'Left'}`;
   if (typeof ret !== 'number') {

--- a/src/util.ts
+++ b/src/util.ts
@@ -8,7 +8,7 @@ export function getMotionName(prefixCls: string, transitionName?: string, animat
 }
 
 // =============================== Offset ===============================
-function getScroll(w: Window, top?: boolean): number {
+function getScroll(w: Window | null | undefined, top?: boolean): number {
   if (!w) return 0;
   let ret = w[`page${top ? 'Y' : 'X'}Offset`];
   const method = `scroll${top ? 'Top' : 'Left'}`;

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,7 +9,9 @@ export function getMotionName(prefixCls: string, transitionName?: string, animat
 
 // =============================== Offset ===============================
 function getScroll(w: Window | null | undefined, top?: boolean): number {
-  if (!w) return 0;
+  if (!w) {
+    return 0;
+  }
   let ret = w[`page${top ? 'Y' : 'X'}Offset`];
   const method = `scroll${top ? 'Top' : 'Left'}`;
   if (typeof ret !== 'number') {

--- a/tests/util.spec.tsx
+++ b/tests/util.spec.tsx
@@ -48,6 +48,33 @@ describe('Dialog.Util', () => {
         top: 1128,
       });
     });
+
+    it('returns zero offset when defaultView and parentWindow are missing', () => {
+      const element = {
+        ownerDocument: {},
+        getBoundingClientRect: () => ({ left: 0, top: 0 }),
+      } as any;
+
+      expect(offset(element)).toEqual({
+        left: 0,
+        top: 0,
+      });
+    });
+
+    it('returns zero offset when defaultView and parentWindow are null or undefined', () => {
+      const element = {
+        ownerDocument: {
+          defaultView: null,
+          parentWindow: undefined,
+        },
+        getBoundingClientRect: () => ({ left: 0, top: 0 }),
+      } as any;
+
+      expect(offset(element)).toEqual({
+        left: 0,
+        top: 0,
+      });
+    });
   });
 
   describe('getMotionName', () => {


### PR DESCRIPTION
https://github.com/react-component/dialog/issues/566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 提升了滚动偏移计算在边界情况下的容错性，减少在缺失或无效窗口引用时的异常，增强稳定性与可靠性。

* **Tests**
  * 新增测试场景，覆盖在缺失或为 null/undefined 的窗口引用下的行为，确保偏移计算返回安全默认值。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->