### PR TITLE
fix: destroyOnHidden should work when forceRender is true

### DIFF
--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -49,7 +49,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
 
   // Destroy on close will remove wrapped div
   // Use `hasOpenedRef` to check if component has ever been opened (after animation completes)
-  if (destroyOnHidden && hasOpenedRef.current && !visible) {
+  if (destroyOnHidden && hasOpenedRef.current && !visible && !animatedVisible) {
     return null;
   }
 

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -46,7 +46,8 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
   }, [visible]);
 
   // Destroy on close will remove wrapped div
-  if (!forceRender && destroyOnHidden && !animatedVisible) {
+  // Use `animatedVisible` to check if component has ever been opened
+  if (destroyOnHidden && animatedVisible && !visible) {
     return null;
   }
 

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -28,6 +28,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
   } = props;
   const { scrollLock: _, ...restProps } = props;
   const [animatedVisible, setAnimatedVisible] = React.useState<boolean>(visible);
+  const hasOpenedRef = React.useRef(false);
 
   const refContext = React.useMemo(() => ({ panel: panelRef }), [panelRef]);
 
@@ -42,12 +43,13 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
   React.useEffect(() => {
     if (visible) {
       setAnimatedVisible(true);
+      hasOpenedRef.current = true;
     }
   }, [visible]);
 
   // Destroy on close will remove wrapped div
-  // Use `animatedVisible` to check if component has ever been opened
-  if (destroyOnHidden && animatedVisible && !visible) {
+  // Use `hasOpenedRef` to check if component has ever been opened (after animation completes)
+  if (destroyOnHidden && hasOpenedRef.current && !visible) {
     return null;
   }
 

--- a/src/DialogWrap.tsx
+++ b/src/DialogWrap.tsx
@@ -28,7 +28,7 @@ const DialogWrap: React.FC<IDialogPropTypes> = (props) => {
   } = props;
   const { scrollLock: _, ...restProps } = props;
   const [animatedVisible, setAnimatedVisible] = React.useState<boolean>(visible);
-  const hasOpenedRef = React.useRef(false);
+  const hasOpenedRef = React.useRef(visible);
 
   const refContext = React.useMemo(() => ({ panel: panelRef }), [panelRef]);
 

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -158,6 +158,32 @@ describe('dialog', () => {
 
       expect(document.querySelector<HTMLInputElement>('.test-input')).toHaveValue('');
     });
+
+    it('should destroy even when forceRender is true', () => {
+      const Demo: React.FC<Partial<DialogProps>> = (props) => (
+        <Dialog forceRender destroyOnHidden {...props}>
+          <input className="test-force-destroy" />
+        </Dialog>
+      );
+
+      const { rerender } = render(<Demo visible={false} />);
+
+      // Force render, but not visible yet - should still render (forceRender)
+      expect(document.querySelectorAll('.test-force-destroy')).toHaveLength(1);
+
+      // Show
+      rerender(<Demo visible />);
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      // Hide - should destroy because destroyOnHidden is true
+      rerender(<Demo visible={false} />);
+      act(() => {
+        jest.runAllTimers();
+      });
+      expect(document.querySelectorAll('.test-force-destroy')).toHaveLength(0);
+    });
   });
 
   it('esc to close', () => {


### PR DESCRIPTION
## Description

修复  forceRender 在 时destroyOnHidden不生效的问题。

### Problem
当同时设置  和  时，隐藏对话框后内容不会被销毁，这与预期行为不符。

### Solution
修改判断逻辑，使用  来检查组件是否曾经打开过，而不是依赖  和  的组合条件。

### 关联issue
https://github.com/ant-design/ant-design/issues/28847

### Changes
- : 调整  的判断条件
- : 添加测试用例

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化对话框隐藏时内容的卸载逻辑，确保在启用“隐藏时销毁”后，内容仅在对话框实际打开过并再次隐藏时被移除。
  - 改善同时启用“强制渲染”和“隐藏时销毁”时的行为：内容会先正常渲染，并在再次隐藏后正确卸载。

- **测试**
  - 增加相关场景测试，验证内容在初始隐藏、显示及再次隐藏阶段的正确状态。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->