### PR TITLE
fix: render numeric zero dialog chrome

### DIFF
--- a/src/Dialog/Content/Panel.tsx
+++ b/src/Dialog/Content/Panel.tsx
@@ -73,7 +73,10 @@ const Panel = React.forwardRef<PanelRef, PanelProps>((props, ref) => {
     contentStyle.height = height;
   }
   // ================================ Render ================================
-  const footerNode = footer ? (
+  const hasFooter = !!footer || footer === 0;
+  const hasTitle = !!title || title === 0;
+
+  const footerNode = hasFooter ? (
     <div
       className={clsx(`${prefixCls}-footer`, modalClassNames?.footer)}
       style={{ ...modalStyles?.footer }}
@@ -82,7 +85,7 @@ const Panel = React.forwardRef<PanelRef, PanelProps>((props, ref) => {
     </div>
   ) : null;
 
-  const headerNode = title ? (
+  const headerNode = hasTitle ? (
     <div
       className={clsx(`${prefixCls}-header`, modalClassNames?.header)}
       style={{ ...modalStyles?.header }}
@@ -146,7 +149,7 @@ const Panel = React.forwardRef<PanelRef, PanelProps>((props, ref) => {
     <div
       key="dialog-element"
       role="dialog"
-      aria-labelledby={title ? ariaId : null}
+      aria-labelledby={hasTitle ? ariaId : null}
       aria-modal="true"
       ref={mergedRef}
       style={{ ...style, ...contentStyle }}

--- a/tests/index.spec.tsx
+++ b/tests/index.spec.tsx
@@ -253,6 +253,15 @@ describe('dialog', () => {
     expect(document.querySelector('.rc-dialog-footer').textContent).toBe('test');
   });
 
+  it('renders numeric zero title and footer', () => {
+    render(<Dialog visible title={0} footer={0} />);
+
+    const title = document.querySelector<HTMLElement>('.rc-dialog-title');
+    expect(title).toHaveTextContent('0');
+    expect(document.querySelector('.rc-dialog-footer')).toHaveTextContent('0');
+    expect(document.querySelector('.rc-dialog')).toHaveAttribute('aria-labelledby', title!.id);
+  });
+
   // 失效了，需要修复
   it.skip('support input autoFocus', () => {
     render(


### PR DESCRIPTION
## Summary

- render numeric `0` passed through the public ReactNode `title` and `footer` props
- keep the dialog's `aria-labelledby` relationship when the title is zero
- cover the header, footer, and accessible-name wiring with a regression test

## Problem

`title` and `footer` accept `ReactNode`, but `Panel` used truthiness checks to decide whether to render them. As a result, a valid numeric zero was silently dropped. For `title={0}`, the title element was also omitted and the dialog lost its `aria-labelledby` reference.

The fix distinguishes numeric zero from other falsy React values while preserving the existing behavior for empty strings, `false`, `null`, and `undefined`.

## Validation

- exact-base regression test failed before the implementation and passes afterward
- full Jest suite: 6 suites passed, 61 tests passed, 1 existing skipped, 4 snapshots passed
- TypeScript (`tsc --noEmit`)
- ESLint (0 errors; one existing file-level unused-disable warning when linting the test directly)
- Prettier check
- `git diff --check`

I checked current open issues and pull requests. I found no report or PR for numeric-zero title/footer rendering. There are older unrelated PRs that also touch `Panel.tsx`, but none changes these render conditions.

AI assistance disclosure: Codex was used to trace the render conditions, audit open issues/PR files, run the exact-base regression, and draft this report. The implementation and test are directly reproducible from this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 修复对话框标题或页脚为数值 `0` 时无法正常显示的问题。
  - 确保标题为 `0` 时，辅助技术关联属性仍能正确指向标题元素。

- **测试**
  - 增加对标题和页脚显示 `0`，以及无障碍关联属性正确性的验证。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->